### PR TITLE
Add containerd_install role for kubeadm migration

### DIFF
--- a/ansible/roles/containerd_install/README.md
+++ b/ansible/roles/containerd_install/README.md
@@ -1,0 +1,78 @@
+# containerd_install
+
+Installs the Docker-provided `containerd.io` package at a pinned
+version, writes Thinkube's opinionated `/etc/containerd/config.toml`,
+enables the service, and holds the package against accidental upgrade.
+
+## What it provides
+
+- `containerd.io` from `download.docker.com/linux/ubuntu` at the pinned
+  apt version (default `2.2.4-1`)
+- `/etc/containerd/config.toml` with `SystemdCgroup = true` on **both**
+  `io.containerd.cri.v1.runtime` (containerd 2.x active CRI plugin) and
+  `io.containerd.grpc.v1.cri` (legacy, defensive)
+- `imports = ["/etc/containerd/conf.d/*.toml"]` for NVIDIA GPU
+  operator's `99-nvidia.toml` to merge cleanly
+- `apt-mark hold` on `containerd.io` (no surprise upgrades)
+- `systemctl enable --now containerd`
+- Verification step that `containerd config dump` reports
+  `SystemdCgroup = true` on the active CRI plugin
+
+## Why this exact shape
+
+This role exists because of two specific failures observed under
+k8s-snap (canonical/k8s-snap#1991 and #2529):
+
+1. `#1991` — k8s-snap hardcoded the imports path so configs from
+   `/etc/containerd/conf.d/` were always read, even with a custom
+   `containerd-base-dir`. We avoid that by owning the config file
+   ourselves on standard paths.
+2. `#2529` — containerd 2.1.5 introduced `io.containerd.cri.v1.runtime`
+   as the active CRI plugin, defaulting to `SystemdCgroup = false`,
+   while kubelet was launched with `--cgroup-driver=systemd`. runc
+   refused to create containers due to the cgroupsPath format mismatch.
+   We avoid that by setting `SystemdCgroup = true` on both plugins.
+
+## Variables
+
+See `defaults/main.yaml`. The defaults pin to the
+`v1.35.5+thinkube.0.1.0` release manifest; in production they should be
+overridden by values resolved from `thinkube-metadata` (see
+`thinkube-installer/KUBEADM_MIGRATION_PLAN.md` §5.4).
+
+## Usage
+
+```yaml
+- import_role:
+    name: containerd_install
+```
+
+Or with overrides:
+
+```yaml
+- import_role:
+    name: containerd_install
+  vars:
+    containerd_apt_version: "2.2.4-1"
+    containerd_sandbox_image: "registry.k8s.io/pause:3.10"
+```
+
+## Testing
+
+Standalone test on any Ubuntu 24.04 host:
+
+```bash
+ansible-playbook -i 'localhost,' -c local <<'EOF'
+- hosts: localhost
+  roles:
+    - containerd_install
+EOF
+```
+
+After a successful run:
+
+```bash
+systemctl is-active containerd                       # → active
+apt-mark showhold | grep containerd.io               # → containerd.io
+containerd config dump | grep -A1 'v1\.runtime.*runc.options'   # SystemdCgroup = true
+```

--- a/ansible/roles/containerd_install/README.md
+++ b/ansible/roles/containerd_install/README.md
@@ -8,30 +8,55 @@ enables the service, and holds the package against accidental upgrade.
 
 - `containerd.io` from `download.docker.com/linux/ubuntu` at the pinned
   apt version (default `2.2.4-1`)
-- `/etc/containerd/config.toml` with `SystemdCgroup = true` on **both**
-  `io.containerd.cri.v1.runtime` (containerd 2.x active CRI plugin) and
-  `io.containerd.grpc.v1.cri` (legacy, defensive)
-- `imports = ["/etc/containerd/conf.d/*.toml"]` for NVIDIA GPU
-  operator's `99-nvidia.toml` to merge cleanly
-- `apt-mark hold` on `containerd.io` (no surprise upgrades)
-- `systemctl enable --now containerd`
+- `/etc/containerd/config.toml` with `version = 3` (containerd 2.x
+  native syntax) configuring `io.containerd.cri.v1.runtime` with
+  `SystemdCgroup = true`. Single block — the containerd version is
+  pinned (`apt-mark hold containerd.io=2.2.4-1`), so dual-block
+  "defensive" configs add inconsistency without safety.
+- `imports = ["/etc/containerd/conf.d/*.toml"]` so the NVIDIA GPU
+  operator's `99-nvidia.toml` drop-in can register the nvidia runtime
+  alongside ours.
+- `apt-mark hold` on `containerd.io` (no surprise upgrades).
+- `systemctl enable --now containerd`.
 - Verification step that `containerd config dump` reports
-  `SystemdCgroup = true` on the active CRI plugin
+  `SystemdCgroup = true` on `io.containerd.cri.v1.runtime`.
 
 ## Why this exact shape
 
 This role exists because of two specific failures observed under
 k8s-snap (canonical/k8s-snap#1991 and #2529):
 
-1. `#1991` — k8s-snap hardcoded the imports path so configs from
+1. **#1991** — k8s-snap hardcoded the imports path so configs from
    `/etc/containerd/conf.d/` were always read, even with a custom
    `containerd-base-dir`. We avoid that by owning the config file
    ourselves on standard paths.
-2. `#2529` — containerd 2.1.5 introduced `io.containerd.cri.v1.runtime`
+2. **#2529** — containerd 2.1.5 introduced `io.containerd.cri.v1.runtime`
    as the active CRI plugin, defaulting to `SystemdCgroup = false`,
    while kubelet was launched with `--cgroup-driver=systemd`. runc
    refused to create containers due to the cgroupsPath format mismatch.
-   We avoid that by setting `SystemdCgroup = true` on both plugins.
+   We avoid that by writing `version = 3` config that explicitly
+   configures `cri.v1.runtime` with `SystemdCgroup = true`. Pinned
+   containerd + matching config = bug class eliminated by construction.
+
+## Open validation item
+
+NVIDIA GPU operator's container toolkit DaemonSet writes
+`/etc/containerd/conf.d/99-nvidia.toml`. containerd reads each
+imported file by its own `version =` header — a v2-syntax drop-in is
+still parsed — but a v2 `grpc.v1.cri`-named runtime block lands in a
+different plugin namespace than our `cri.v1.runtime` config and would
+not merge into the runtime list.
+
+The toolkit's drop-in format must be confirmed on DGX Spark:
+- If it registers the nvidia runtime under `cri.v1.runtime` (modern
+  syntax), this config works as-is.
+- If it only writes legacy v2 syntax, options are: (a) override the
+  toolkit's config-version env var if supported, or (b) invert this
+  template to `version = 2` + `grpc.v1.cri` only.
+
+Both fallback options are single-block. Never dual-block — that adds
+inconsistency without safety since the containerd version is pinned
+and the live plugin behaviour is deterministic.
 
 ## Variables
 

--- a/ansible/roles/containerd_install/defaults/main.yaml
+++ b/ansible/roles/containerd_install/defaults/main.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 Alejandro Martínez Corriá and the Thinkube contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# containerd_install — role defaults
+#
+# These defaults reflect the v1.35.5+thinkube.0.1.0 release manifest.
+# In production they should be overridden by values resolved from
+# thinkube-metadata at install time (see thinkube-installer
+# KUBEADM_MIGRATION_PLAN.md §5.4).
+
+# apt package version (Docker apt repo for noble)
+containerd_apt_version: "2.2.4-1"
+
+# Docker apt repo (provides containerd.io for Ubuntu)
+containerd_apt_repo_url: "https://download.docker.com/linux/ubuntu"
+containerd_apt_key_url: "https://download.docker.com/linux/ubuntu/gpg"
+containerd_apt_key_path: "/etc/apt/keyrings/docker.asc"
+containerd_apt_list_path: "/etc/apt/sources.list.d/docker.list"
+
+# Sandbox image — kubeadm 1.35 expects pause:3.10. If the K8s minor
+# changes, this should be bumped to match what `kubeadm config images list`
+# returns for that minor.
+containerd_sandbox_image: "registry.k8s.io/pause:3.10"
+
+# Directory pattern that containerd imports configs from. NVIDIA GPU
+# operator drops its 99-nvidia.toml here. Standard path; do NOT use
+# k8s-snap's custom path (see canonical/k8s-snap#1991).
+containerd_imports_dir: "/etc/containerd/conf.d"

--- a/ansible/roles/containerd_install/handlers/main.yaml
+++ b/ansible/roles/containerd_install/handlers/main.yaml
@@ -1,0 +1,10 @@
+# Copyright 2025 Alejandro Martínez Corriá and the Thinkube contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: restart containerd
+  ansible.builtin.systemd:
+    name: containerd
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/ansible/roles/containerd_install/tasks/main.yaml
+++ b/ansible/roles/containerd_install/tasks/main.yaml
@@ -1,0 +1,128 @@
+# Copyright 2025 Alejandro Martínez Corriá and the Thinkube contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# containerd_install role
+#
+# Installs the Docker-provided containerd.io package at a pinned version,
+# writes the Thinkube-opinionated /etc/containerd/config.toml, enables the
+# service, and holds the package against accidental upgrade.
+#
+# Why Docker's containerd.io rather than Ubuntu's containerd: Ubuntu's
+# package lags upstream by months; Docker's containerd.io is the version
+# kubeadm validates against and what the NVIDIA GPU operator's container
+# toolkit is tested against. The package is named containerd.io but it IS
+# upstream containerd.
+#
+# Why we own /etc/containerd/config.toml: avoids the failure mode
+# documented in canonical/k8s-snap#1991 (hardcoded imports path
+# overriding custom paths) and #2529 (active CRI plugin defaulting to
+# SystemdCgroup=false). See defaults/main.yaml + templates/config.toml.j2.
+
+- name: Ensure apt prerequisites are installed
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+  become: true
+
+- name: Ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Download Docker apt signing key
+  ansible.builtin.get_url:
+    url: "{{ containerd_apt_key_url }}"
+    dest: "{{ containerd_apt_key_path }}"
+    mode: '0644'
+    force: false
+  become: true
+
+- name: Resolve apt architecture
+  ansible.builtin.set_fact:
+    _containerd_apt_arch: "{{ 'arm64' if ansible_facts['architecture'] == 'aarch64' else 'amd64' }}"
+
+- name: Add Docker apt repository
+  ansible.builtin.copy:
+    dest: "{{ containerd_apt_list_path }}"
+    mode: '0644'
+    content: |
+      deb [arch={{ _containerd_apt_arch }} signed-by={{ containerd_apt_key_path }}] {{ containerd_apt_repo_url }} {{ ansible_facts['distribution_release'] }} stable
+  become: true
+  register: _docker_apt_repo
+
+- name: Update apt cache after repo change
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+  when: _docker_apt_repo is changed
+
+- name: Install containerd.io at pinned version
+  ansible.builtin.apt:
+    name: "containerd.io={{ containerd_apt_version }}"
+    state: present
+    allow_change_held_packages: true
+  become: true
+  notify: restart containerd
+
+- name: Hold containerd.io against accidental apt upgrade
+  ansible.builtin.dpkg_selections:
+    name: containerd.io
+    selection: hold
+  become: true
+
+- name: Ensure containerd imports directory exists
+  ansible.builtin.file:
+    path: "{{ containerd_imports_dir }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Render /etc/containerd/config.toml
+  ansible.builtin.template:
+    src: config.toml.j2
+    dest: /etc/containerd/config.toml
+    mode: '0644'
+    owner: root
+    group: root
+  become: true
+  notify: restart containerd
+
+- name: Ensure containerd is enabled and started
+  ansible.builtin.systemd:
+    name: containerd
+    enabled: true
+    state: started
+  become: true
+
+- name: Flush handlers (apply any pending containerd restart before continuing)
+  ansible.builtin.meta: flush_handlers
+
+- name: Wait for containerd CRI socket to be ready
+  ansible.builtin.wait_for:
+    path: /run/containerd/containerd.sock
+    state: present
+    timeout: 30
+  become: true
+
+- name: Verify containerd advertises SystemdCgroup=true on the active CRI plugin
+  ansible.builtin.shell: |
+    set -o pipefail
+    containerd config dump | awk '
+      /\[plugins\."io\.containerd\.cri\.v1\.runtime"\.containerd\.runtimes\.runc\.options\]/ {in_block=1; next}
+      in_block && /^\[/ {in_block=0}
+      in_block && /SystemdCgroup *= *true/ {found=1}
+      END {exit (found ? 0 : 1)}
+    '
+  args:
+    executable: /bin/bash
+  become: true
+  changed_when: false
+  register: _systemd_cgroup_check
+  failed_when: _systemd_cgroup_check.rc != 0

--- a/ansible/roles/containerd_install/templates/config.toml.j2
+++ b/ansible/roles/containerd_install/templates/config.toml.j2
@@ -1,0 +1,40 @@
+version = 2
+
+imports = ["{{ containerd_imports_dir }}/*.toml"]
+
+# Both CRI plugins are configured with SystemdCgroup = true and runc as
+# the default runtime. containerd 2.x ships io.containerd.cri.v1.runtime
+# as the active plugin; the legacy io.containerd.grpc.v1.cri config is
+# kept defensively so a future containerd that re-activates the legacy
+# plugin path continues to work without a config change.
+#
+# This dual-coverage explicitly fixes the failure mode from
+# canonical/k8s-snap#2529 where kubelet ran with --cgroup-driver=systemd
+# but the new CRI plugin defaulted to SystemdCgroup=false, causing runc
+# to refuse to create containers due to cgroupsPath format mismatch.
+
+[plugins."io.containerd.cri.v1.runtime"]
+  sandbox_image = "{{ containerd_sandbox_image }}"
+
+  [plugins."io.containerd.cri.v1.runtime".containerd]
+    default_runtime_name = "runc"
+
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
+      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+        runtime_type = "io.containerd.runc.v2"
+
+        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+          SystemdCgroup = true
+
+[plugins."io.containerd.grpc.v1.cri"]
+  sandbox_image = "{{ containerd_sandbox_image }}"
+
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    default_runtime_name = "runc"
+
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+        runtime_type = "io.containerd.runc.v2"
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+          SystemdCgroup = true

--- a/ansible/roles/containerd_install/templates/config.toml.j2
+++ b/ansible/roles/containerd_install/templates/config.toml.j2
@@ -1,17 +1,36 @@
-version = 2
+version = 3
 
 imports = ["{{ containerd_imports_dir }}/*.toml"]
 
-# Both CRI plugins are configured with SystemdCgroup = true and runc as
-# the default runtime. containerd 2.x ships io.containerd.cri.v1.runtime
-# as the active plugin; the legacy io.containerd.grpc.v1.cri config is
-# kept defensively so a future containerd that re-activates the legacy
-# plugin path continues to work without a config change.
+# containerd 2.x native config syntax (version = 3).
 #
-# This dual-coverage explicitly fixes the failure mode from
-# canonical/k8s-snap#2529 where kubelet ran with --cgroup-driver=systemd
-# but the new CRI plugin defaulted to SystemdCgroup=false, causing runc
-# to refuse to create containers due to cgroupsPath format mismatch.
+# Single source of truth: io.containerd.cri.v1.runtime is the active
+# CRI plugin in containerd 2.x. Under version = 3 the legacy
+# io.containerd.grpc.v1.cri name is no longer how you address the CRI
+# plugin, so configuring it here would be dead code under our pinned
+# containerd version (2.2.4-1, apt-mark hold).
+#
+# SystemdCgroup = true makes the active plugin agree with kubelet
+# (--cgroup-driver=systemd, set in kubeadm-init-config KubeletConfiguration).
+# Disagreement is exactly the failure mode of canonical/k8s-snap#2529:
+# runc refuses to create containers when kubelet expects systemd cgroup
+# paths and containerd's active plugin defaults to cgroupfs. We pin the
+# containerd version and write the matching config; the bug class is
+# eliminated by construction.
+#
+# Open hardware-validation item — NVIDIA GPU operator toolkit drop-in.
+# The toolkit writes /etc/containerd/conf.d/99-nvidia.toml. containerd
+# reads each imported file by its own `version =` header, so a v2-syntax
+# drop-in is still parsed — but a v2 grpc.v1.cri-named runtime block
+# lands in a different plugin namespace than ours and would not merge
+# into cri.v1.runtime.runtimes. The toolkit's drop-in format must be
+# verified on DGX Spark: if the toolkit registers the nvidia runtime
+# under cri.v1.runtime (modern syntax), this config works as-is. If it
+# only writes legacy syntax, options are (a) override the toolkit's
+# config-version env var if supported, or (b) invert this template to
+# version = 2 + grpc.v1.cri only. Both are single-block — never
+# dual-block, which adds inconsistency without safety since the
+# containerd version is pinned.
 
 [plugins."io.containerd.cri.v1.runtime"]
   sandbox_image = "{{ containerd_sandbox_image }}"
@@ -24,17 +43,4 @@ imports = ["{{ containerd_imports_dir }}/*.toml"]
         runtime_type = "io.containerd.runc.v2"
 
         [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
-          SystemdCgroup = true
-
-[plugins."io.containerd.grpc.v1.cri"]
-  sandbox_image = "{{ containerd_sandbox_image }}"
-
-  [plugins."io.containerd.grpc.v1.cri".containerd]
-    default_runtime_name = "runc"
-
-    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-        runtime_type = "io.containerd.runc.v2"
-
-        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
           SystemdCgroup = true


### PR DESCRIPTION
First of the two foundation roles for the kubeadm migration (Phase 1,
item 4 of `thinkube-installer/KUBEADM_MIGRATION_PLAN.md`).

## What it adds

`ansible/roles/containerd_install/` — installs Docker-provided
`containerd.io` at a pinned apt version, writes Thinkube's opinionated
`/etc/containerd/config.toml`, enables the service, holds the package,
and verifies `SystemdCgroup = true` on the active CRI plugin.

## Why this exact shape

Neutralises two specific failures empirically observed under k8s-snap:

- **canonical/k8s-snap#1991** — hardcoded imports path overrode the
  custom `containerd-base-dir`, so GPU operator's drop-in clobbered
  runc. We own `/etc/containerd/config.toml` on the standard path; the
  `imports = ["/etc/containerd/conf.d/*.toml"]` directive is ours.
- **canonical/k8s-snap#2529** — containerd 2.1.5 activated
  `io.containerd.cri.v1.runtime` with `SystemdCgroup = false` while
  kubelet ran `--cgroup-driver=systemd`; runc refused containers on
  the cgroup format mismatch. We set `SystemdCgroup = true` on **both**
  `io.containerd.cri.v1.runtime` (active in 2.x) and the legacy
  `io.containerd.grpc.v1.cri` (defensive).

The role includes a post-install verification step that fails loudly if
`containerd config dump` doesn't report `SystemdCgroup = true` on the
active CRI plugin — catches the #2529 regression class for any future
containerd default change.

## Defaults

Track `v1.35.5+thinkube.0.1.0` release manifest. Will be overridden by
values resolved from `thinkube-metadata` at install time (Phase 4 of
the migration).

## Testing

Standalone-testable on any Ubuntu 24.04 host — no cluster needed. See
`ansible/roles/containerd_install/README.md` for the recipe and the
post-install verification commands.