### PR TITLE
Add kubeadm_install role for kubeadm migration

### DIFF
--- a/ansible/roles/kubeadm_install/README.md
+++ b/ansible/roles/kubeadm_install/README.md
@@ -1,0 +1,91 @@
+# kubeadm_install
+
+Installs `kubeadm`, `kubelet`, `kubectl` from the upstream `pkgs.k8s.io`
+apt repository at a pinned version, applies kubeadm's preflight
+requirements, and holds the packages.
+
+## What it provides
+
+- `kubeadm`, `kubelet`, `kubectl` from
+  `pkgs.k8s.io/core:/stable:/v<MINOR>/deb/` at the pinned patch (default
+  `1.35.5-1.1`)
+- `apt-mark hold` on all three
+- Swap disabled (runtime + `/etc/fstab` comment)
+- Kernel modules `overlay` and `br_netfilter` loaded + persisted via
+  `/etc/modules-load.d/thinkube-k8s.conf`
+- Networking sysctls (`net.bridge.bridge-nf-call-iptables=1`,
+  `net.bridge.bridge-nf-call-ip6tables=1`, `net.ipv4.ip_forward=1`)
+  persisted via `/etc/sysctl.d/99-thinkube-k8s.conf`
+- `kubelet` systemd unit enabled
+
+## What it does NOT provide
+
+- `kubeadm init` / `kubeadm join` — handled by the orchestrating
+  playbooks (`infrastructure/k8s/10_install_k8s.yaml` for control
+  plane, `20_join_workers.yaml` for workers)
+- containerd — handled by the `containerd_install` role
+- Cilium / CoreDNS / GPU operator — separate playbooks
+
+## Why each step
+
+Standard upstream kubeadm requirements. Documented in
+<https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/>
+and the kubeadm preflight checks themselves. After install, kubelet
+enters a crashloop until kubeadm configures it; this is the
+upstream-documented behaviour, not a bug.
+
+The apt-pinned versions + `apt-mark hold` exist to neutralise the same
+class of failure that canonical/k8s-snap#2529 demonstrated under snap
+auto-refresh: version bumps must be explicit and intentional.
+
+## Variables
+
+See `defaults/main.yaml`. The defaults pin to the
+`v1.35.5+thinkube.0.1.0` release manifest; in production they should be
+overridden by values resolved from `thinkube-metadata` (see
+`thinkube-installer/KUBEADM_MIGRATION_PLAN.md` §5.4).
+
+## Usage
+
+```yaml
+- import_role:
+    name: kubeadm_install
+```
+
+Or with overrides:
+
+```yaml
+- import_role:
+    name: kubeadm_install
+  vars:
+    kubeadm_k8s_minor: "1.35"
+    kubeadm_k8s_patch: "1.35.5"
+    kubeadm_k8s_apt_revision: "1.1"
+```
+
+## Testing
+
+Standalone test on any Ubuntu 24.04 host (the role does NOT require
+containerd to be already installed; kubelet will crashloop without it,
+which is expected and harmless):
+
+```bash
+ansible-playbook -i 'localhost,' -c local <<'EOF'
+- hosts: localhost
+  roles:
+    - kubeadm_install
+EOF
+```
+
+After a successful run:
+
+```bash
+which kubeadm kubelet kubectl                  # → /usr/bin/...
+kubeadm version | grep GitVersion              # → v1.35.5
+apt-mark showhold | grep -E 'kubeadm|kubelet|kubectl'   # → all three
+swapon --show                                  # → empty
+sysctl net.ipv4.ip_forward                     # → 1
+lsmod | grep -E 'overlay|br_netfilter'         # → both present
+systemctl is-enabled kubelet                   # → enabled
+systemctl is-active kubelet                    # → activating/failing (expected — no kubeadm config yet)
+```

--- a/ansible/roles/kubeadm_install/defaults/main.yaml
+++ b/ansible/roles/kubeadm_install/defaults/main.yaml
@@ -1,0 +1,43 @@
+# Copyright 2025 Alejandro Martínez Corriá and the Thinkube contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# kubeadm_install — role defaults
+#
+# These defaults reflect the v1.35.5+thinkube.0.1.0 release manifest.
+# In production they should be overridden by values resolved from
+# thinkube-metadata at install time (see thinkube-installer
+# KUBEADM_MIGRATION_PLAN.md §5.4).
+
+# Kubernetes minor.patch
+kubeadm_k8s_minor: "1.35"
+kubeadm_k8s_patch: "1.35.5"
+kubeadm_k8s_apt_revision: "1.1"
+
+# apt repo (note: each K8s minor has its own repo URL — pkgs.k8s.io
+# uses minor-versioned repositories, not a single "stable" path)
+kubeadm_apt_repo_url: "https://pkgs.k8s.io/core:/stable:/v{{ kubeadm_k8s_minor }}/deb/"
+kubeadm_apt_key_url:  "https://pkgs.k8s.io/core:/stable:/v{{ kubeadm_k8s_minor }}/deb/Release.key"
+kubeadm_apt_key_path: "/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+kubeadm_apt_list_path: "/etc/apt/sources.list.d/kubernetes.list"
+
+# Packages to install + hold
+kubeadm_apt_packages:
+  - "kubeadm={{ kubeadm_k8s_patch }}-{{ kubeadm_k8s_apt_revision }}"
+  - "kubelet={{ kubeadm_k8s_patch }}-{{ kubeadm_k8s_apt_revision }}"
+  - "kubectl={{ kubeadm_k8s_patch }}-{{ kubeadm_k8s_apt_revision }}"
+kubeadm_apt_hold:
+  - kubeadm
+  - kubelet
+  - kubectl
+
+# Required kernel modules (kubeadm preflight)
+kubeadm_kernel_modules:
+  - overlay
+  - br_netfilter
+
+# Required sysctls (kubeadm preflight — networking)
+kubeadm_sysctls:
+  - { key: "net.bridge.bridge-nf-call-iptables",  value: "1" }
+  - { key: "net.bridge.bridge-nf-call-ip6tables", value: "1" }
+  - { key: "net.ipv4.ip_forward",                 value: "1" }

--- a/ansible/roles/kubeadm_install/tasks/main.yaml
+++ b/ansible/roles/kubeadm_install/tasks/main.yaml
@@ -1,0 +1,159 @@
+# Copyright 2025 Alejandro Martínez Corriá and the Thinkube contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# kubeadm_install role
+#
+# Installs kubeadm + kubelet + kubectl from the upstream pkgs.k8s.io
+# apt repository at a pinned version, applies kubeadm's preflight
+# requirements (swap off, kernel modules, sysctls), and holds the
+# packages.
+#
+# Does NOT run `kubeadm init` or `kubeadm join` — that's the
+# responsibility of the orchestrating playbook
+# (40_thinkube/core/infrastructure/k8s/10_install_k8s.yaml for control
+# plane, 20_join_workers.yaml for workers).
+#
+# After this role completes, kubelet is enabled but will crashloop
+# until kubeadm configures it (standard upstream pattern — see
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/).
+
+# -----------------------------------------------------------------------------
+# Preflight: swap off
+# -----------------------------------------------------------------------------
+- name: Disable swap (runtime)
+  ansible.builtin.command: swapoff -a
+  become: true
+  changed_when: false  # idempotent; check below catches persistence
+
+- name: Detect swap entries in /etc/fstab
+  ansible.builtin.shell: |
+    grep -E '^[^#].*\s+swap\s+' /etc/fstab || true
+  register: _swap_fstab
+  changed_when: false
+
+- name: Comment out swap entries in /etc/fstab (persist across reboot)
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^([^#].*\s+swap\s+.*)$'
+    replace: '# \1  # disabled by Thinkube (kubeadm requirement)'
+  become: true
+  when: _swap_fstab.stdout | length > 0
+
+# -----------------------------------------------------------------------------
+# Preflight: kernel modules
+# -----------------------------------------------------------------------------
+- name: Declare required kernel modules for load-on-boot
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/thinkube-k8s.conf
+    mode: '0644'
+    content: |
+      # Required by kubeadm. Managed by Thinkube (do not edit).
+      {% for mod in kubeadm_kernel_modules %}
+      {{ mod }}
+      {% endfor %}
+  become: true
+
+- name: Load required kernel modules now
+  community.general.modprobe:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ kubeadm_kernel_modules }}"
+  become: true
+
+# -----------------------------------------------------------------------------
+# Preflight: networking sysctls
+# -----------------------------------------------------------------------------
+- name: Declare required sysctls for persistence
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/99-thinkube-k8s.conf
+    mode: '0644'
+    content: |
+      # Required by kubeadm. Managed by Thinkube (do not edit).
+      {% for s in kubeadm_sysctls %}
+      {{ s.key }} = {{ s.value }}
+      {% endfor %}
+  become: true
+  register: _sysctl_file
+
+- name: Apply sysctls now (sysctl --system)
+  ansible.builtin.command: sysctl --system
+  become: true
+  changed_when: _sysctl_file is changed
+
+# -----------------------------------------------------------------------------
+# apt: keyring + repo + install + hold
+# -----------------------------------------------------------------------------
+- name: Ensure apt prerequisites are installed
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gpg
+    state: present
+    update_cache: true
+  become: true
+
+- name: Ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Fetch Kubernetes apt signing key
+  ansible.builtin.get_url:
+    url: "{{ kubeadm_apt_key_url }}"
+    dest: "/tmp/kubernetes-apt-key.asc"
+    mode: '0644'
+    force: true
+  become: true
+
+- name: Convert key to keyring binary form
+  ansible.builtin.command: >
+    gpg --dearmor --batch --yes --output {{ kubeadm_apt_key_path }} /tmp/kubernetes-apt-key.asc
+  args:
+    creates: "{{ kubeadm_apt_key_path }}"
+  become: true
+
+- name: Remove temporary armored key
+  ansible.builtin.file:
+    path: /tmp/kubernetes-apt-key.asc
+    state: absent
+  become: true
+
+- name: Add Kubernetes apt repository
+  ansible.builtin.copy:
+    dest: "{{ kubeadm_apt_list_path }}"
+    mode: '0644'
+    content: |
+      deb [signed-by={{ kubeadm_apt_key_path }}] {{ kubeadm_apt_repo_url }} /
+  become: true
+  register: _k8s_apt_repo
+
+- name: Update apt cache after repo change
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+  when: _k8s_apt_repo is changed
+
+- name: Install kubeadm / kubelet / kubectl at pinned versions
+  ansible.builtin.apt:
+    name: "{{ kubeadm_apt_packages }}"
+    state: present
+    allow_change_held_packages: true
+  become: true
+
+- name: Hold kubeadm / kubelet / kubectl against accidental upgrade
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ kubeadm_apt_hold }}"
+  become: true
+
+- name: Ensure kubelet is enabled (it will crashloop until kubeadm configures it)
+  ansible.builtin.systemd:
+    name: kubelet
+    enabled: true
+  become: true


### PR DESCRIPTION
Second of the two foundation roles for the kubeadm migration (Phase 1,
item 4 of `thinkube-installer/KUBEADM_MIGRATION_PLAN.md`).

## What it adds

`ansible/roles/kubeadm_install/` — installs `kubeadm` + `kubelet` +
`kubectl` from the upstream `pkgs.k8s.io` apt repository at a pinned
version, applies kubeadm's preflight requirements (swap off,
`overlay` + `br_netfilter` kernel modules, networking sysctls), and
holds the packages.

## What it does NOT do

- `kubeadm init` / `kubeadm join` — handled by the orchestrating
  playbooks in Phase 2 (`infrastructure/k8s/10_install_k8s.yaml` for
  control plane, `20_join_workers.yaml` for workers). The role is kept
  generic so both the control-plane and worker playbooks can call it
  via `import_role`.
- containerd installation — handled by the sibling `containerd_install`
  role.

## Why apt-mark hold matters

Neutralises the same class of failure that
canonical/k8s-snap#2529 demonstrated under snap auto-refresh: version
bumps must be explicit and intentional, not delivered overnight by a
package manager.

## Defaults

Track `v1.35.5+thinkube.0.1.0` release manifest. Will be overridden by
values resolved from `thinkube-metadata` at install time (Phase 4 of
the migration).

## Testing

Standalone-testable on any Ubuntu 24.04 host — no cluster needed.
kubelet will crashloop until kubeadm configures it; this is the
upstream-documented behaviour, not a bug. See
`ansible/roles/kubeadm_install/README.md` for the recipe and the
post-install verification commands.