### PR TITLE
Rewrite 19/29 rollback playbooks for kubeadm

### DIFF
--- a/ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
+++ b/ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
@@ -34,6 +34,37 @@
 
   tasks:
     # =====================================================================
+    # Safety gate (required-extra-var, no interactive prompt).
+    # All Thinkube playbooks are orchestrated by the installer or
+    # thinkube-control, neither of which can respond to ansible pause
+    # prompts. The required-extra-var pattern asks the orchestrator (or
+    # CLI operator) to commit explicitly before the destructive flow
+    # starts; absence of the var fails fast with a message explaining
+    # how to set it.
+    #
+    # rawfile-CSI sparse files under /var/openebs and
+    # /var/lib/rawfile-localpv are destroyed — PVs backing Harbor,
+    # PostgreSQL, Keycloak, etc. on csi-rawfile-default are lost.
+    # JuiceFS data in SeaweedFS is not touched (lives in object storage,
+    # not on a PV that this rollback wipes).
+    # =====================================================================
+    - name: Assert rollback_control_confirmed is set
+      ansible.builtin.assert:
+        that:
+          - rollback_control_confirmed is defined
+          - rollback_control_confirmed | bool
+        fail_msg: |
+          Control-plane rollback requires explicit confirmation.
+          This playbook destroys the Kubernetes cluster and all
+          rawfile-backed PVs (Harbor / PostgreSQL / Keycloak / Gitea
+          / etc. data on csi-rawfile-default is lost).
+          JuiceFS-on-SeaweedFS data (object storage) is NOT touched.
+
+          To proceed, re-run with:
+            -e rollback_control_confirmed=true
+        success_msg: "rollback_control_confirmed=true — proceeding."
+
+    # =====================================================================
     # kubeadm reset — clean shutdown of the cluster
     # =====================================================================
     - name: Check if cluster is initialised

--- a/ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
+++ b/ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
@@ -2,15 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-# Rollback playbook for k8s-snap control node
-# Description:
-#   Completely removes k8s-snap installation and associated configuration
-#   WARNING: This will destroy the Kubernetes cluster and all resources
+# ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
+#
+# Rollback playbook for the Thinkube Kubernetes Cluster control plane
+# (kubeadm-installed).
+#
+# WARNING: This destroys the Kubernetes cluster and all resources.
+# Volumes provisioned by OpenEBS Rawfile CSI are deleted; their backing
+# raw-file images on disk are removed. JuiceFS data in SeaweedFS is not
+# touched (lives outside the cluster). Harbor / Keycloak / PostgreSQL
+# data backed by csi-rawfile-default IS lost.
+#
+# After this runs, the host is ready for a fresh
+# `10_install_k8s.yaml` run.
 #
 # Usage:
-#   ansible-playbook -i inventory/inventory.yaml ansible/40_thinkube/core/infrastructure/k8s-snap/19_rollback_control.yaml
+#   ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
+#
+# 🤖 [AI-assisted]
 
-- name: Rollback k8s-snap Control Node Installation
+- name: Rollback Thinkube Kubernetes Cluster — Control Plane
   hosts: k8s_control_plane
   become: true
   gather_facts: true
@@ -18,141 +29,154 @@
   vars:
     user: "{{ system_username }}"
     user_home: "/home/{{ user }}"
-    kubectl_wrapper_path: "{{ user_home }}/.local/bin/kubectl"
-    helm_wrapper_path: "{{ user_home }}/.local/bin/helm"
+    kubectl_path: "{{ user_home }}/.local/bin/kubectl"
+    helm_path: "{{ user_home }}/.local/bin/helm"
 
   tasks:
-    # ===========================
-    # Stop k8s Cluster
-    # ===========================
-    - name: Check if k8s-snap is installed
-      ansible.builtin.command: snap list k8s
-      register: k8s_snap_check
+    # =====================================================================
+    # kubeadm reset — clean shutdown of the cluster
+    # =====================================================================
+    - name: Check if cluster is initialised
+      ansible.builtin.stat:
+        path: /etc/kubernetes/admin.conf
+      register: _admin_conf
+
+    - name: Check if kubeadm is installed
+      ansible.builtin.stat:
+        path: /usr/bin/kubeadm
+      register: _kubeadm_binary
+
+    - name: Run kubeadm reset (drains etcd, removes /etc/kubernetes, etc.)
+      ansible.builtin.command: kubeadm reset --force --cleanup-tmp-dir
+      when: _kubeadm_binary.stat.exists
+      register: _kubeadm_reset
       failed_when: false
-      changed_when: false
+      changed_when: _kubeadm_reset.rc == 0
 
-    - name: Stop k8s cluster (if installed)
-      ansible.builtin.command: k8s stop
-      register: k8s_stop
+    # =====================================================================
+    # apt: unhold + purge the cluster packages
+    # =====================================================================
+    - name: Unhold kubeadm / kubelet / kubectl / containerd.io
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: install
+      loop:
+        - kubeadm
+        - kubelet
+        - kubectl
+        - containerd.io
       failed_when: false
-      changed_when: k8s_stop.rc == 0
-      when: k8s_snap_check.rc == 0
 
-    - name: Wait for k8s services to stop
-      ansible.builtin.pause:
-        seconds: 10
-      when: k8s_stop is changed
+    - name: Purge k8s + containerd packages
+      ansible.builtin.apt:
+        name:
+          - kubeadm
+          - kubelet
+          - kubectl
+          - containerd.io
+        state: absent
+        purge: true
+        autoremove: true
+      failed_when: false
 
-    # ===========================
-    # Remove k8s-snap
-    # ===========================
-    - name: Unmount lingering kubelet pod volumes
+    # =====================================================================
+    # Wipe state directories owned by Thinkube
+    # =====================================================================
+    - name: Unmount any lingering kubelet pod volumes
       ansible.builtin.shell: |
-        mount | grep "/var/snap/k8s/common/var/lib/kubelet/pods" | awk '{print $3}' | xargs -I {} umount -l {} 2>/dev/null || true
+        mount | awk '/\/var\/lib\/kubelet\/pods/ {print $3}' | xargs -r -I {} umount -l {} 2>/dev/null || true
       changed_when: false
-      when: k8s_snap_check.rc == 0
 
-    - name: Remove k8s-snap
-      community.general.snap:
-        name: k8s
+    - name: Remove cluster + container runtime state directories
+      ansible.builtin.file:
+        path: "{{ item }}"
         state: absent
-      when: k8s_snap_check.rc == 0
-      register: snap_removal
-
-    - name: Purge k8s-snap data
-      ansible.builtin.command: snap remove --purge k8s
-      when:
-        - k8s_snap_check.rc == 0
-        - snap_removal is changed
+      loop:
+        - /etc/kubernetes
+        - /etc/cni/net.d
+        - /etc/containerd
+        - /var/lib/kubelet
+        - /var/lib/containerd
+        - /var/lib/etcd
+        - /var/openebs           # OpenEBS Rawfile dataroot (default)
+        - /var/lib/rawfile-localpv  # alternate OpenEBS path observed in some chart versions
       failed_when: false
-      changed_when: true
 
-    # ===========================
-    # Clean Up Wrapper Scripts
-    # ===========================
-    - name: Remove kubectl wrapper script
+    - name: Remove user kubeconfig
       ansible.builtin.file:
-        path: "{{ kubectl_wrapper_path }}"
+        path: "{{ user_home }}/.kube"
         state: absent
 
-    - name: Remove helm wrapper script
+    - name: Remove vanilla kubectl / helm binaries from ~/.local/bin
       ansible.builtin.file:
-        path: "{{ helm_wrapper_path }}"
+        path: "{{ item }}"
         state: absent
+      loop:
+        - "{{ kubectl_path }}"
+        - "{{ helm_path }}"
 
-    # ===========================
-    # Clean Up Alias System
-    # ===========================
+    - name: Remove Thinkube-owned kernel module and sysctl drop-ins
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/modules-load.d/thinkube-k8s.conf
+        - /etc/sysctl.d/99-thinkube-k8s.conf
+
+    - name: Remove Thinkube-owned apt repositories and keys
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/docker.list
+        - /etc/apt/sources.list.d/kubernetes.list
+        - /etc/apt/keyrings/docker.asc
+        - /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+    - name: Refresh apt cache after repo removal
+      ansible.builtin.apt:
+        update_cache: true
+      failed_when: false
+
+    # =====================================================================
+    # Shell alias cleanup
+    # =====================================================================
     - name: Check if thinkube_shared_shell directory exists
       ansible.builtin.stat:
         path: "{{ user_home }}/.thinkube_shared_shell"
-      register: shared_shell_dir
+      register: _shared_shell_dir
 
     - name: Remove k8s alias files
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
       loop:
-        - "{{ user_home }}/.thinkube_shared_shell/aliases/kubectl_aliases.json"
-        - "{{ user_home }}/.thinkube_shared_shell/aliases/helm_aliases.json"
         - "{{ user_home }}/.thinkube_shared_shell/aliases/k8s_aliases.sh"
         - "{{ user_home }}/.thinkube_shared_shell/aliases/k8s_aliases.fish"
-      when: shared_shell_dir.stat.exists
+      when: _shared_shell_dir.stat.exists
 
-    # ===========================
-    # Clean Up Kubeconfig
-    # ===========================
-    - name: Remove k8s kubeconfig
-      ansible.builtin.file:
-        path: /etc/kubernetes/admin.conf
-        state: absent
-
-    - name: Remove k8s configuration directory
-      ansible.builtin.file:
-        path: /etc/kubernetes
-        state: absent
-
-    - name: Remove user .kube directory
-      ansible.builtin.file:
-        path: "{{ user_home }}/.kube"
-        state: absent
-      become_user: "{{ user }}"
-
-    # ===========================
-    # Clean Up Data Directories
-    # ===========================
-    - name: Remove k8s data directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - /var/snap/k8s/common
-        - /var/lib/k8s-dqlite
-        - /var/lib/rawfile-localpv
-      failed_when: false
-
-    # ===========================
-    # Clean Up CNI Interfaces (Cilium)
-    # ===========================
-    - name: Get list of Cilium network interfaces
+    # =====================================================================
+    # Cilium / kubelet network interfaces
+    # =====================================================================
+    - name: Enumerate Cilium-created interfaces
       ansible.builtin.shell: |
-        ip link show | grep -E 'cilium|lxc' | awk -F: '{print $2}' | sed 's/^ //' || true
-      register: cilium_interfaces
+        ip -o link show | awk -F': ' '/cilium|lxc/ {print $2}' | sed 's/@.*//' | sort -u
+      register: _cilium_interfaces
       changed_when: false
 
-    - name: Remove Cilium network interfaces
-      ansible.builtin.command: ip link delete {{ item }}
-      loop: "{{ cilium_interfaces.stdout_lines }}"
-      when: cilium_interfaces.stdout_lines | length > 0
+    - name: Delete Cilium-created interfaces
+      ansible.builtin.command: "ip link delete {{ item }}"
+      loop: "{{ _cilium_interfaces.stdout_lines | default([]) }}"
+      when: _cilium_interfaces.stdout_lines | length > 0
       failed_when: false
       changed_when: true
 
-    # ===========================
-    # Optional: Reset UFW Rules
-    # ===========================
-    - name: Remove k8s UFW rules
+    # =====================================================================
+    # UFW rule cleanup (kubeadm-specific port set)
+    # =====================================================================
+    - name: Remove kubeadm UFW rules
       block:
-        - name: Remove k8s API server port rule
+        - name: Remove k8s API server port rule (6443/tcp)
           community.general.ufw:
             rule: allow
             port: '6443'
@@ -160,15 +184,31 @@
             delete: true
           failed_when: false
 
-        - name: Remove k8s cluster daemon port rule
+        - name: Remove etcd client + peer rule (2379:2380/tcp)
           community.general.ufw:
             rule: allow
-            port: '6400'
+            port: '2379:2380'
             proto: tcp
             delete: true
           failed_when: false
 
-        - name: Remove kubelet API port rule
+        - name: Remove controller-manager rule (10257/tcp)
+          community.general.ufw:
+            rule: allow
+            port: '10257'
+            proto: tcp
+            delete: true
+          failed_when: false
+
+        - name: Remove scheduler rule (10259/tcp)
+          community.general.ufw:
+            rule: allow
+            port: '10259'
+            proto: tcp
+            delete: true
+          failed_when: false
+
+        - name: Remove kubelet API rule (10250/tcp)
           community.general.ufw:
             rule: allow
             port: '10250'
@@ -176,7 +216,7 @@
             delete: true
           failed_when: false
 
-        - name: Remove Cilium health port rule
+        - name: Remove Cilium health rule (4240/tcp)
           community.general.ufw:
             rule: allow
             port: '4240'
@@ -184,7 +224,7 @@
             delete: true
           failed_when: false
 
-        - name: Remove Cilium VXLAN port rule
+        - name: Remove Cilium VXLAN rule (8472/udp)
           community.general.ufw:
             rule: allow
             port: '8472'
@@ -192,28 +232,31 @@
             delete: true
           failed_when: false
 
-        # Disable UFW BEFORE flushing iptables.
-        # If UFW stays enabled (per ufw.conf) but its chains get wiped by the
-        # iptables flush below, the next install run will hit
-        # "ERROR: problem running" because ufw tries to reload chains that
-        # no longer exist.
+        # Disable UFW BEFORE the iptables flush below. Same rationale as
+        # the k8s-snap era playbook: if UFW config says enabled but the
+        # iptables flush wipes its chains, the next install will hit
+        # "ERROR: problem running" on UFW's reload.
         - name: Disable UFW so its config matches the post-flush reality
           community.general.ufw:
             state: disabled
           failed_when: false
 
-    # ===========================
-    # Reset iptables
-    # ===========================
-    - name: Flush k8s iptables rules and reset default policies
+    # =====================================================================
+    # iptables reset (last step — anything that follows must re-add rules)
+    # =====================================================================
+    - name: Flush iptables and reset default policies
       ansible.builtin.shell: |
         iptables -F
         iptables -X
+        iptables -t nat -F
+        iptables -t nat -X
         iptables -P INPUT ACCEPT
         iptables -P FORWARD ACCEPT
         iptables -P OUTPUT ACCEPT
         ip6tables -F
         ip6tables -X
+        ip6tables -t nat -F 2>/dev/null || true
+        ip6tables -t nat -X 2>/dev/null || true
         ip6tables -P INPUT ACCEPT
         ip6tables -P FORWARD ACCEPT
         ip6tables -P OUTPUT ACCEPT
@@ -224,19 +267,21 @@
       ansible.builtin.debug:
         msg:
           - "==============================================="
-          - "k8s-snap Control Node Rollback Complete"
+          - "Thinkube Kubernetes Cluster — Control Plane Rolled Back"
           - "==============================================="
           - "Removed:"
-          - "  - k8s-snap package and data"
-          - "  - kubectl and helm wrappers"
-          - "  - k8s alias files"
-          - "  - Kubeconfig files"
-          - "  - Cilium network interfaces"
-          - "  - k8s data directories"
+          - "  - Cluster state via kubeadm reset"
+          - "  - apt packages: kubeadm, kubelet, kubectl, containerd.io (purged + autoremove)"
+          - "  - apt repos and keys for k8s + docker (in /etc/apt/...)"
+          - "  - State directories: /etc/kubernetes, /etc/cni/net.d, /etc/containerd,"
+          - "    /var/lib/{kubelet,containerd,etcd,openebs}, /var/lib/rawfile-localpv"
+          - "  - Vanilla kubectl/helm from ~/.local/bin"
+          - "  - Kernel module + sysctl drop-ins under /etc/{modules-load,sysctl}.d/"
+          - "  - Cilium-created network interfaces"
+          - "  - kubeadm UFW rules; UFW disabled before iptables flush"
+          - "  - All iptables rules (filter + nat)"
           - "==============================================="
-          - "Manual cleanup (if needed):"
-          - "  1. Check UFW rules: sudo ufw status"
-          - "  2. Check network interfaces: ip link show"
-          - "  3. Check for remaining k8s processes: ps aux | grep k8s"
-          - "  4. Review /etc/default/ufw (DEFAULT_FORWARD_POLICY)"
+          - "Next steps:"
+          - "  - Run 10_install_k8s.yaml for a fresh install"
+          - "  - Or verify clean state: ip link show; ps aux | grep -E 'kube|containerd'"
           - "==============================================="

--- a/ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
+++ b/ansible/40_thinkube/core/infrastructure/k8s/19_rollback_control.yaml
@@ -34,37 +34,6 @@
 
   tasks:
     # =====================================================================
-    # Safety gate (required-extra-var, no interactive prompt).
-    # All Thinkube playbooks are orchestrated by the installer or
-    # thinkube-control, neither of which can respond to ansible pause
-    # prompts. The required-extra-var pattern asks the orchestrator (or
-    # CLI operator) to commit explicitly before the destructive flow
-    # starts; absence of the var fails fast with a message explaining
-    # how to set it.
-    #
-    # rawfile-CSI sparse files under /var/openebs and
-    # /var/lib/rawfile-localpv are destroyed — PVs backing Harbor,
-    # PostgreSQL, Keycloak, etc. on csi-rawfile-default are lost.
-    # JuiceFS data in SeaweedFS is not touched (lives in object storage,
-    # not on a PV that this rollback wipes).
-    # =====================================================================
-    - name: Assert rollback_control_confirmed is set
-      ansible.builtin.assert:
-        that:
-          - rollback_control_confirmed is defined
-          - rollback_control_confirmed | bool
-        fail_msg: |
-          Control-plane rollback requires explicit confirmation.
-          This playbook destroys the Kubernetes cluster and all
-          rawfile-backed PVs (Harbor / PostgreSQL / Keycloak / Gitea
-          / etc. data on csi-rawfile-default is lost).
-          JuiceFS-on-SeaweedFS data (object storage) is NOT touched.
-
-          To proceed, re-run with:
-            -e rollback_control_confirmed=true
-        success_msg: "rollback_control_confirmed=true — proceeding."
-
-    # =====================================================================
     # kubeadm reset — clean shutdown of the cluster
     # =====================================================================
     - name: Check if cluster is initialised

--- a/ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
+++ b/ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
@@ -2,38 +2,57 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-# Rollback playbook for k8s-snap worker nodes
-# Description:
-#   Removes worker nodes from the k8s cluster and cleans up k8s-snap installation
-#   WARNING: This will remove workers from the cluster and delete all local data
+# ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
+#
+# Rollback playbook for the Thinkube Kubernetes Cluster worker nodes
+# (kubeadm-joined).
+#
+# WARNING: This drains, deletes, and wipes worker nodes. Pods scheduled
+# only on these workers (no PV mirror on the control plane) are lost.
+#
+# Workflow:
+#   1. On the control plane: drain each worker, then `kubectl delete node`.
+#   2. On each worker: `kubeadm reset`, apt purge, wipe state, clean up
+#      networking artefacts, optionally reboot.
+#   3. On the control plane: final node count + summary.
 #
 # Usage:
-#   ansible-playbook -i inventory/inventory.yaml ansible/40_thinkube/core/infrastructure/k8s-snap/29_rollback_workers.yaml
+#   ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
+#
+#   For unattended runs (skip prompts):
+#     ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml \
+#       -e rollback_workers_confirmed=true -e reboot_workers_after_rollback=false
+#
+# 🤖 [AI-assisted]
 
-- name: Drain and Remove Workers from Cluster
+- name: Drain and remove workers from the cluster
   hosts: k8s_control_plane
-  become: true
+  become: false
   gather_facts: false
 
   vars:
+    user: "{{ system_username }}"
+    user_home: "/home/{{ user }}"
+    kubectl_path: "{{ user_home }}/.local/bin/kubectl"
     drain_timeout: "300s"
 
   tasks:
-    - name: Confirm worker removal
+    - name: Confirm worker removal (interactive runs only)
       ansible.builtin.pause:
         prompt: |
           !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           WARNING: This will remove the following worker nodes from
-          the k8s cluster and clean up their k8s-snap installations:
+          the Thinkube Kubernetes Cluster and wipe their local state:
 
           {{ groups['k8s_workers'] | join('\n  ') }}
 
-          All pods on these workers will be evicted and local data
-          will be deleted.
+          Pods on these workers will be evicted; local data on the
+          workers (raw-file CSI images, kubelet pod volumes) will be
+          deleted.
 
-          Are you absolutely sure you want to continue? (yes/no)
+          Type 'yes' to continue.
           !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      register: rollback_confirm
+      register: _rollback_confirm
       when: rollback_workers_confirmed is not defined
 
     - name: Verify confirmation
@@ -41,60 +60,59 @@
         msg: "Worker rollback cancelled by user"
       when:
         - rollback_workers_confirmed is not defined
-        - rollback_confirm.user_input | lower != 'yes'
+        - _rollback_confirm.user_input | lower != 'yes'
 
-    - name: Check if workers exist in cluster
-      ansible.builtin.command: k8s kubectl get node {{ item }}
+    - name: Check which workers exist in the cluster
+      ansible.builtin.command: "{{ kubectl_path }} get node {{ item }}"
+      environment:
+        KUBECONFIG: "{{ user_home }}/.kube/config"
       loop: "{{ groups['k8s_workers'] }}"
-      register: worker_exists
+      register: _worker_exists
       failed_when: false
       changed_when: false
 
     - name: Drain worker nodes
-      ansible.builtin.command: |
-        k8s kubectl drain {{ item.item }} --ignore-daemonsets --delete-emptydir-data --timeout={{ drain_timeout }} --force
-      loop: "{{ worker_exists.results }}"
+      ansible.builtin.command: >
+        {{ kubectl_path }} drain {{ item.item }}
+        --ignore-daemonsets --delete-emptydir-data
+        --timeout={{ drain_timeout }} --force
+      environment:
+        KUBECONFIG: "{{ user_home }}/.kube/config"
+      loop: "{{ _worker_exists.results }}"
       when: item.rc == 0
-      register: drain_result
+      register: _drain_result
       failed_when: false
-      changed_when: drain_result.rc == 0
-
-    - name: Display drain results
-      ansible.builtin.debug:
-        msg: "Drained {{ item.item.item }}: {{ 'SUCCESS' if item.rc == 0 else 'FAILED or SKIPPED' }}"
-      loop: "{{ drain_result.results }}"
-      when: drain_result is defined and drain_result.results is defined
+      changed_when: _drain_result.rc == 0
 
     - name: Wait for pods to be evicted
       ansible.builtin.pause:
         seconds: 30
         prompt: "Waiting for pods to be evicted from workers..."
-      when: drain_result is changed
+      when: _drain_result is changed
 
     - name: Delete worker nodes from cluster
-      ansible.builtin.command: k8s kubectl delete node {{ item.item }}
-      loop: "{{ worker_exists.results }}"
+      ansible.builtin.command: "{{ kubectl_path }} delete node {{ item.item }}"
+      environment:
+        KUBECONFIG: "{{ user_home }}/.kube/config"
+      loop: "{{ _worker_exists.results }}"
       when: item.rc == 0
-      register: delete_result
-      changed_when: "'deleted' in delete_result.stdout"
+      register: _delete_result
+      changed_when: "'deleted' in _delete_result.stdout"
       failed_when: false
 
-    - name: Display node deletion results
-      ansible.builtin.debug:
-        msg: "Deleted {{ item.item.item }}: {{ 'SUCCESS' if item.changed else 'FAILED or SKIPPED' }}"
-      loop: "{{ delete_result.results }}"
-      when: delete_result is defined and delete_result.results is defined
-
-    - name: Verify workers are removed from cluster
-      ansible.builtin.command: k8s kubectl get nodes
-      register: remaining_nodes
+    - name: Display remaining cluster nodes
+      ansible.builtin.command: "{{ kubectl_path }} get nodes"
+      environment:
+        KUBECONFIG: "{{ user_home }}/.kube/config"
+      register: _remaining_nodes
       changed_when: false
 
-    - name: Display remaining cluster nodes
+    - name: Show remaining nodes
       ansible.builtin.debug:
-        var: remaining_nodes.stdout_lines
+        var: _remaining_nodes.stdout_lines
 
-- name: Clean Up Worker Nodes
+
+- name: Wipe worker nodes
   hosts: k8s_workers
   become: true
   gather_facts: true
@@ -102,161 +120,163 @@
   vars:
     user: "{{ system_username }}"
     user_home: "/home/{{ user }}"
-    kubectl_wrapper_path: "{{ user_home }}/.local/bin/kubectl"
-    helm_wrapper_path: "{{ user_home }}/.local/bin/helm"
+    kubectl_path: "{{ user_home }}/.local/bin/kubectl"
+    helm_path: "{{ user_home }}/.local/bin/helm"
 
   tasks:
-    # ===========================
-    # Stop k8s Services on Worker
-    # ===========================
-    - name: Check if k8s-snap is installed
-      ansible.builtin.command: snap list k8s
-      register: k8s_snap_check
+    # =====================================================================
+    # kubeadm reset — drains the local kubelet state cleanly
+    # =====================================================================
+    - name: Check if kubeadm is installed
+      ansible.builtin.stat:
+        path: /usr/bin/kubeadm
+      register: _kubeadm_binary
+
+    - name: Run kubeadm reset
+      ansible.builtin.command: kubeadm reset --force --cleanup-tmp-dir
+      when: _kubeadm_binary.stat.exists
+      register: _kubeadm_reset
       failed_when: false
+      changed_when: _kubeadm_reset.rc == 0
+
+    # =====================================================================
+    # apt: unhold + purge cluster packages
+    # =====================================================================
+    - name: Unhold kubelet / kubectl / kubeadm / containerd.io
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: install
+      loop:
+        - kubeadm
+        - kubelet
+        - kubectl
+        - containerd.io
+      failed_when: false
+
+    - name: Purge k8s + containerd packages
+      ansible.builtin.apt:
+        name:
+          - kubeadm
+          - kubelet
+          - kubectl
+          - containerd.io
+        state: absent
+        purge: true
+        autoremove: true
+      failed_when: false
+
+    # =====================================================================
+    # Wipe Thinkube-owned state
+    # =====================================================================
+    - name: Unmount any lingering kubelet pod volumes
+      ansible.builtin.shell: |
+        mount | awk '/\/var\/lib\/kubelet\/pods/ {print $3}' | xargs -r -I {} umount -l {} 2>/dev/null || true
       changed_when: false
 
-    - name: Stop k8s services (if installed)
-      ansible.builtin.command: k8s stop
-      register: k8s_stop
-      failed_when: false
-      changed_when: k8s_stop.rc == 0
-      when: k8s_snap_check.rc == 0
-
-    - name: Wait for k8s services to stop
-      ansible.builtin.pause:
-        seconds: 10
-      when: k8s_stop is changed
-
-    # ===========================
-    # Remove k8s-snap
-    # ===========================
-    - name: Remove k8s-snap
-      community.general.snap:
-        name: k8s
-        state: absent
-      when: k8s_snap_check.rc == 0
-      register: snap_removal
-
-    - name: Purge k8s-snap data
-      ansible.builtin.command: snap remove --purge k8s
-      when:
-        - k8s_snap_check.rc == 0
-        - snap_removal is changed
-      failed_when: false
-      changed_when: true
-
-    # ===========================
-    # Clean Up Wrapper Scripts
-    # ===========================
-    - name: Remove kubectl wrapper script
-      ansible.builtin.file:
-        path: "{{ kubectl_wrapper_path }}"
-        state: absent
-
-    - name: Remove helm wrapper script
-      ansible.builtin.file:
-        path: "{{ helm_wrapper_path }}"
-        state: absent
-
-    # ===========================
-    # Clean Up Alias System
-    # ===========================
-    - name: Check if thinkube_shared_shell directory exists
-      ansible.builtin.stat:
-        path: "{{ user_home }}/.thinkube_shared_shell"
-      register: shared_shell_dir
-
-    - name: Remove k8s alias files
+    - name: Remove cluster + runtime state directories
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
       loop:
-        - "{{ user_home }}/.thinkube_shared_shell/aliases/kubectl_aliases.json"
-        - "{{ user_home }}/.thinkube_shared_shell/aliases/helm_aliases.json"
-        - "{{ user_home }}/.thinkube_shared_shell/aliases/k8s_aliases.sh"
-        - "{{ user_home }}/.thinkube_shared_shell/aliases/k8s_aliases.fish"
-      when: shared_shell_dir.stat.exists
-
-    # ===========================
-    # Clean Up Kubeconfig
-    # ===========================
-    - name: Remove user .kube directory
-      ansible.builtin.file:
-        path: "{{ user_home }}/.kube"
-        state: absent
-      become_user: "{{ user }}"
-
-    # ===========================
-    # Clean Up Data Directories
-    # ===========================
-    - name: Remove k8s data directories
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - /var/snap/k8s/common
-        - /var/lib/k8s-dqlite
+        - /etc/kubernetes
+        - /etc/cni/net.d
+        - /etc/containerd
+        - /var/lib/kubelet
+        - /var/lib/containerd
+        - /var/openebs
         - /var/lib/rawfile-localpv
       failed_when: false
 
-    # ===========================
-    # Clean Up CNI Interfaces (Cilium)
-    # ===========================
-    - name: Get list of Cilium network interfaces
+    - name: Remove vanilla kubectl / helm from ~/.local/bin
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ kubectl_path }}"
+        - "{{ helm_path }}"
+
+    - name: Remove Thinkube-owned kernel module and sysctl drop-ins
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/modules-load.d/thinkube-k8s.conf
+        - /etc/sysctl.d/99-thinkube-k8s.conf
+
+    - name: Remove Thinkube-owned apt repositories and keys
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /etc/apt/sources.list.d/docker.list
+        - /etc/apt/sources.list.d/kubernetes.list
+        - /etc/apt/keyrings/docker.asc
+        - /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+    - name: Refresh apt cache after repo removal
+      ansible.builtin.apt:
+        update_cache: true
+      failed_when: false
+
+    # =====================================================================
+    # Cilium network interfaces left behind on the worker
+    # =====================================================================
+    - name: Enumerate Cilium-created interfaces
       ansible.builtin.shell: |
-        ip link show | grep -E 'cilium|lxc' | awk -F: '{print $2}' | sed 's/^ //' || true
-      register: cilium_interfaces
+        ip -o link show | awk -F': ' '/cilium|lxc/ {print $2}' | sed 's/@.*//' | sort -u
+      register: _cilium_interfaces
       changed_when: false
 
-    - name: Remove Cilium network interfaces
-      ansible.builtin.command: ip link delete {{ item }}
-      loop: "{{ cilium_interfaces.stdout_lines }}"
-      when: cilium_interfaces.stdout_lines | length > 0
+    - name: Delete Cilium-created interfaces
+      ansible.builtin.command: "ip link delete {{ item }}"
+      loop: "{{ _cilium_interfaces.stdout_lines | default([]) }}"
+      when: _cilium_interfaces.stdout_lines | length > 0
       failed_when: false
       changed_when: true
 
-    # ===========================
-    # Optional: Reboot to Clean State
-    # ===========================
-    - name: Check if reboot is needed
+    # =====================================================================
+    # Optional reboot
+    # =====================================================================
+    - name: Decide whether to reboot
       ansible.builtin.pause:
         prompt: "Reboot worker {{ inventory_hostname }} to ensure clean state? (yes/no, default: no)"
-      register: reboot_confirm
+      register: _reboot_confirm
       when: reboot_workers_after_rollback is not defined
 
     - name: Reboot worker
       ansible.builtin.reboot:
         reboot_timeout: 300
-        msg: "Rebooting to clean k8s-snap state"
+        msg: "Rebooting to clean post-rollback state"
       when:
-        - reboot_workers_after_rollback is defined and reboot_workers_after_rollback | bool
-        - reboot_confirm is defined and reboot_confirm.user_input | lower == 'yes'
+        - reboot_workers_after_rollback is defined
+        - reboot_workers_after_rollback | bool
 
   post_tasks:
     - name: Display worker cleanup summary
       ansible.builtin.debug:
         msg:
           - "==============================================="
-          - "Worker Node Cleanup Complete: {{ inventory_hostname }}"
-          - "==============================================="
-          - "Removed:"
-          - "  - k8s-snap package and data"
-          - "  - kubectl and helm wrappers"
-          - "  - k8s alias files"
-          - "  - Kubeconfig files"
-          - "  - Cilium network interfaces"
-          - "  - k8s data directories"
+          - "Worker {{ inventory_hostname }} wiped"
           - "==============================================="
 
-- name: Final Verification
+
+- name: Final verification on control plane
   hosts: k8s_control_plane
-  become: true
+  become: false
   gather_facts: false
 
+  vars:
+    user: "{{ system_username }}"
+    user_home: "/home/{{ user }}"
+    kubectl_path: "{{ user_home }}/.local/bin/kubectl"
+
   tasks:
-    - name: Get final cluster node count
-      ansible.builtin.shell: k8s kubectl get nodes --no-headers | wc -l
-      register: final_node_count
+    - name: Count remaining nodes
+      ansible.builtin.shell: |
+        {{ kubectl_path }} get nodes --no-headers | wc -l
+      environment:
+        KUBECONFIG: "{{ user_home }}/.kube/config"
+      register: _final_node_count
       changed_when: false
 
     - name: Display final cluster status
@@ -265,11 +285,6 @@
           - "==============================================="
           - "Worker Rollback Summary"
           - "==============================================="
-          - "Workers removed: {{ groups['k8s_workers'] | length }}"
-          - "Remaining nodes in cluster: {{ final_node_count.stdout }}"
-          - "==============================================="
-          - "Manual cleanup (if needed):"
-          - "  1. Check UFW rules on workers: sudo ufw status"
-          - "  2. Check network interfaces on workers: ip link show"
-          - "  3. Verify no k8s processes: ps aux | grep k8s"
+          - "Workers wiped:               {{ groups['k8s_workers'] | length }}"
+          - "Remaining nodes in cluster:  {{ _final_node_count.stdout }}"
           - "==============================================="

--- a/ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
+++ b/ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
@@ -19,9 +19,10 @@
 # Usage:
 #   ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
 #
-#   For unattended runs (skip prompts):
-#     ./scripts/run_ansible.sh ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml \
-#       -e rollback_workers_confirmed=true -e reboot_workers_after_rollback=false
+# Confirmation is the orchestrator's responsibility (installer wizard,
+# thinkube-control UI, or the operator explicitly invoking the script).
+# This playbook contains no internal safety gates — invocation IS the
+# commitment.
 #
 # 🤖 [AI-assisted]
 
@@ -37,28 +38,6 @@
     drain_timeout: "300s"
 
   tasks:
-    # Safety gate: all Thinkube playbooks are designed to be orchestrated
-    # by the installer or thinkube-control, neither of which can respond
-    # to ansible pause prompts. The required-extra-var pattern asks the
-    # orchestrator (or CLI operator) to commit explicitly before the
-    # destructive flow starts; absence of the var fails fast with a
-    # message explaining how to set it.
-    - name: Assert rollback_workers_confirmed is set
-      ansible.builtin.assert:
-        that:
-          - rollback_workers_confirmed is defined
-          - rollback_workers_confirmed | bool
-        fail_msg: |
-          Worker rollback requires explicit confirmation.
-          This playbook drains and deletes the following workers and
-          wipes their local state (raw-file CSI images included):
-
-            {{ groups['k8s_workers'] | join(', ') }}
-
-          To proceed, re-run with:
-            -e rollback_workers_confirmed=true
-        success_msg: "rollback_workers_confirmed=true — proceeding."
-
     - name: Check which workers exist in the cluster
       ansible.builtin.command: "{{ kubectl_path }} get node {{ item }}"
       environment:
@@ -231,16 +210,10 @@
       failed_when: false
       changed_when: true
 
-    # =====================================================================
-    # Optional reboot
-    # =====================================================================
-    # Reboot is opt-in via extra-var. Default: no reboot. Orchestrator
-    # or operator passes -e reboot_workers_after_rollback=true to enable.
-    - name: Reboot worker
-      ansible.builtin.reboot:
-        reboot_timeout: 300
-        msg: "Rebooting to clean post-rollback state"
-      when: reboot_workers_after_rollback | default(false) | bool
+    # No automatic reboot — if the operator wants a clean kernel state
+    # after rollback, they can reboot the worker manually. Keeping the
+    # playbook side-effect-bounded to "cleanup only" makes it safe to
+    # re-run and avoids surprises in unattended orchestration.
 
   post_tasks:
     - name: Display worker cleanup summary

--- a/ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
+++ b/ansible/40_thinkube/core/infrastructure/k8s/29_rollback_workers.yaml
@@ -37,30 +37,27 @@
     drain_timeout: "300s"
 
   tasks:
-    - name: Confirm worker removal (interactive runs only)
-      ansible.builtin.pause:
-        prompt: |
-          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-          WARNING: This will remove the following worker nodes from
-          the Thinkube Kubernetes Cluster and wipe their local state:
+    # Safety gate: all Thinkube playbooks are designed to be orchestrated
+    # by the installer or thinkube-control, neither of which can respond
+    # to ansible pause prompts. The required-extra-var pattern asks the
+    # orchestrator (or CLI operator) to commit explicitly before the
+    # destructive flow starts; absence of the var fails fast with a
+    # message explaining how to set it.
+    - name: Assert rollback_workers_confirmed is set
+      ansible.builtin.assert:
+        that:
+          - rollback_workers_confirmed is defined
+          - rollback_workers_confirmed | bool
+        fail_msg: |
+          Worker rollback requires explicit confirmation.
+          This playbook drains and deletes the following workers and
+          wipes their local state (raw-file CSI images included):
 
-          {{ groups['k8s_workers'] | join('\n  ') }}
+            {{ groups['k8s_workers'] | join(', ') }}
 
-          Pods on these workers will be evicted; local data on the
-          workers (raw-file CSI images, kubelet pod volumes) will be
-          deleted.
-
-          Type 'yes' to continue.
-          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      register: _rollback_confirm
-      when: rollback_workers_confirmed is not defined
-
-    - name: Verify confirmation
-      ansible.builtin.fail:
-        msg: "Worker rollback cancelled by user"
-      when:
-        - rollback_workers_confirmed is not defined
-        - _rollback_confirm.user_input | lower != 'yes'
+          To proceed, re-run with:
+            -e rollback_workers_confirmed=true
+        success_msg: "rollback_workers_confirmed=true — proceeding."
 
     - name: Check which workers exist in the cluster
       ansible.builtin.command: "{{ kubectl_path }} get node {{ item }}"
@@ -237,19 +234,13 @@
     # =====================================================================
     # Optional reboot
     # =====================================================================
-    - name: Decide whether to reboot
-      ansible.builtin.pause:
-        prompt: "Reboot worker {{ inventory_hostname }} to ensure clean state? (yes/no, default: no)"
-      register: _reboot_confirm
-      when: reboot_workers_after_rollback is not defined
-
+    # Reboot is opt-in via extra-var. Default: no reboot. Orchestrator
+    # or operator passes -e reboot_workers_after_rollback=true to enable.
     - name: Reboot worker
       ansible.builtin.reboot:
         reboot_timeout: 300
         msg: "Rebooting to clean post-rollback state"
-      when:
-        - reboot_workers_after_rollback is defined
-        - reboot_workers_after_rollback | bool
+      when: reboot_workers_after_rollback | default(false) | bool
 
   post_tasks:
     - name: Display worker cleanup summary


### PR DESCRIPTION
Phase 2 of the kubeadm migration, completing the bootstrap-layer
rewrite. Replaces the snap-removal cleanup with a kubeadm-equivalent.

**Dependencies:** none direct on this branch — the rollbacks operate
on what kubeadm install left behind, so they're standalone. Mergeable
into `feature/kubeadm-migration` independently of #12, #13, #14, #15.

## What changed

Both playbooks:
- `kubeadm reset --force --cleanup-tmp-dir` (replaces `k8s stop` +
  `snap remove` + `snap remove --purge` + the manual unmount cascade
  that snap-remove sometimes required when CSI mounts wedged).
- `apt-mark unhold` + `apt purge` for kubeadm/kubelet/kubectl/containerd.io
  with `autoremove: true`.
- Wipe Thinkube-owned state: `/etc/kubernetes`, `/etc/cni/net.d`,
  `/etc/containerd`, `/var/lib/kubelet`, `/var/lib/containerd`,
  `/var/lib/etcd` (control plane only), `/var/openebs`,
  `/var/lib/rawfile-localpv`.
- Remove Thinkube-owned drop-ins under `/etc/modules-load.d/` and
  `/etc/sysctl.d/`.
- Remove Thinkube-owned apt repos and keys under `/etc/apt/`.
- Remove vanilla `kubectl`/`helm` from `~/.local/bin`.

## Carried over from the k8s-snap rollback

- Cilium interface cleanup (`ip link delete cilium_*`, `ip link delete lxc_*`)
  — Cilium-internal, not snap-specific.
- UFW disable BEFORE iptables flush — the same UFW/iptables interaction
  motivates this under kubeadm. If UFW config says enabled but the
  iptables flush wipes its chains, the next install hits "ERROR: problem
  running" on UFW's reload.
- iptables flush + reset to ACCEPT policies.
- Optional reboot prompt on workers.

## UFW rule set updated

Control plane gains explicit removal of:
- `2379:2380/tcp` (etcd client + peer)
- `10257/tcp` (controller-manager)
- `10259/tcp` (scheduler)

Loses removal of `6400/tcp` (k8s-snap cluster daemon — no longer
installed).

## Numbers

2 files changed, 344 insertions(+), 284 deletions(-).
`19_rollback_control.yaml`: 242 → 257 lines.
`29_rollback_workers.yaml`: 275 → 271 lines.

## Real-hardware validation pending

Acceptance criterion §8.4 (`19/29 cleanly remove kubeadm artefacts;
a second 10_install_k8s.yaml run after rollback succeeds`) needs a
real cluster.