### PR TITLE
Quality lint: forbid interactive ansible pause prompts

### DIFF
--- a/ansible/00_initial_setup/19_reset_ssh_config.yaml
+++ b/ansible/00_initial_setup/19_reset_ssh_config.yaml
@@ -40,25 +40,6 @@
           
           ═════════════════════════════════════════════════════════
     
-    # Required-extra-var gate: this playbook is invoked by operators or
-    # orchestrators (installer / thinkube-control); neither can respond
-    # to an interactive pause prompt. Set -e ssh_reset_confirmed=true to
-    # proceed.
-    - name: Assert ssh_reset_confirmed is set
-      ansible.builtin.assert:
-        that:
-          - ssh_reset_confirmed is defined
-          - ssh_reset_confirmed | bool
-        fail_msg: |
-          SSH config reset requires explicit confirmation.
-          This removes Thinkube SSH keys, config entries, and authorized_keys
-          entries. SSH PASSWORD AUTHENTICATION will be REQUIRED after this
-          operation.
-
-          To proceed, re-run with:
-            -e ssh_reset_confirmed=true
-        success_msg: "ssh_reset_confirmed=true — proceeding."
-    
     - name: Backup SSH config file if it exists
       ansible.builtin.copy:
         src: "{{ ansible_user_dir }}/.ssh/config"

--- a/ansible/00_initial_setup/19_reset_ssh_config.yaml
+++ b/ansible/00_initial_setup/19_reset_ssh_config.yaml
@@ -40,9 +40,24 @@
           
           ═════════════════════════════════════════════════════════
     
-    - name: Add pause for confirmation
-      ansible.builtin.pause:
-        prompt: "Press ENTER to continue with SSH configuration reset or Ctrl+C to abort"
+    # Required-extra-var gate: this playbook is invoked by operators or
+    # orchestrators (installer / thinkube-control); neither can respond
+    # to an interactive pause prompt. Set -e ssh_reset_confirmed=true to
+    # proceed.
+    - name: Assert ssh_reset_confirmed is set
+      ansible.builtin.assert:
+        that:
+          - ssh_reset_confirmed is defined
+          - ssh_reset_confirmed | bool
+        fail_msg: |
+          SSH config reset requires explicit confirmation.
+          This removes Thinkube SSH keys, config entries, and authorized_keys
+          entries. SSH PASSWORD AUTHENTICATION will be REQUIRED after this
+          operation.
+
+          To proceed, re-run with:
+            -e ssh_reset_confirmed=true
+        success_msg: "ssh_reset_confirmed=true — proceeding."
     
     - name: Backup SSH config file if it exists
       ansible.builtin.copy:

--- a/ansible/00_initial_setup/29_reset_environment.yaml
+++ b/ansible/00_initial_setup/29_reset_environment.yaml
@@ -37,25 +37,6 @@
           
           ═════════════════════════════════════════════════════════
     
-    # Required-extra-var gate: this playbook is invoked by operators or
-    # orchestrators (installer / thinkube-control); neither can respond
-    # to an interactive pause prompt. Set -e env_reset_confirmed=true to
-    # proceed.
-    - name: Assert env_reset_confirmed is set
-      ansible.builtin.assert:
-        that:
-          - env_reset_confirmed is defined
-          - env_reset_confirmed | bool
-        fail_msg: |
-          Environment reset requires explicit confirmation.
-          This removes Thinkube environment variables from .env and shell
-          rc files. Environment variables will NOT be available after
-          this operation until you re-run the environment setup playbook.
-
-          To proceed, re-run with:
-            -e env_reset_confirmed=true
-        success_msg: "env_reset_confirmed=true — proceeding."
-    
     - name: Check if .env file exists
       ansible.builtin.stat:
         path: "{{ lookup('env', 'HOME') }}/.env"

--- a/ansible/00_initial_setup/29_reset_environment.yaml
+++ b/ansible/00_initial_setup/29_reset_environment.yaml
@@ -37,9 +37,24 @@
           
           ═════════════════════════════════════════════════════════
     
-    - name: Add pause for confirmation
-      ansible.builtin.pause:
-        prompt: "Press ENTER to continue with environment reset or Ctrl+C to abort"
+    # Required-extra-var gate: this playbook is invoked by operators or
+    # orchestrators (installer / thinkube-control); neither can respond
+    # to an interactive pause prompt. Set -e env_reset_confirmed=true to
+    # proceed.
+    - name: Assert env_reset_confirmed is set
+      ansible.builtin.assert:
+        that:
+          - env_reset_confirmed is defined
+          - env_reset_confirmed | bool
+        fail_msg: |
+          Environment reset requires explicit confirmation.
+          This removes Thinkube environment variables from .env and shell
+          rc files. Environment variables will NOT be available after
+          this operation until you re-run the environment setup playbook.
+
+          To proceed, re-run with:
+            -e env_reset_confirmed=true
+        success_msg: "env_reset_confirmed=true — proceeding."
     
     - name: Check if .env file exists
       ansible.builtin.stat:

--- a/ansible/10_baremetal_infra/19_restore_direct_network.yaml
+++ b/ansible/10_baremetal_infra/19_restore_direct_network.yaml
@@ -39,25 +39,6 @@
           
           ═════════════════════════════════════════════════════════
     
-    # Required-extra-var gate: this playbook is invoked by operators or
-    # orchestrators (installer / thinkube-control); neither can respond
-    # to an interactive pause prompt. Set -e network_restore_confirmed=true
-    # to proceed.
-    - name: Assert network_restore_confirmed is set
-      ansible.builtin.assert:
-        that:
-          - network_restore_confirmed is defined
-          - network_restore_confirmed | bool
-        fail_msg: |
-          Direct network restoration requires explicit confirmation.
-          This removes bridge interfaces, restores direct network
-          connectivity, and configures a FIXED IP ({{ ansible_host }}).
-          The SSH connection will likely be disrupted temporarily.
-
-          To proceed, re-run with:
-            -e network_restore_confirmed=true
-        success_msg: "network_restore_confirmed=true — proceeding."
-    
     # Backup current network configuration
     - name: Backup current network configuration state to /tmp
       ansible.builtin.shell: |

--- a/ansible/10_baremetal_infra/19_restore_direct_network.yaml
+++ b/ansible/10_baremetal_infra/19_restore_direct_network.yaml
@@ -39,10 +39,24 @@
           
           ═════════════════════════════════════════════════════════
     
-    # Critical user confirmation
-    - name: Confirm before proceeding
-      ansible.builtin.pause:
-        prompt: "Press ENTER to proceed with network restoration or Ctrl+C to abort"
+    # Required-extra-var gate: this playbook is invoked by operators or
+    # orchestrators (installer / thinkube-control); neither can respond
+    # to an interactive pause prompt. Set -e network_restore_confirmed=true
+    # to proceed.
+    - name: Assert network_restore_confirmed is set
+      ansible.builtin.assert:
+        that:
+          - network_restore_confirmed is defined
+          - network_restore_confirmed | bool
+        fail_msg: |
+          Direct network restoration requires explicit confirmation.
+          This removes bridge interfaces, restores direct network
+          connectivity, and configures a FIXED IP ({{ ansible_host }}).
+          The SSH connection will likely be disrupted temporarily.
+
+          To proceed, re-run with:
+            -e network_restore_confirmed=true
+        success_msg: "network_restore_confirmed=true — proceeding."
     
     # Backup current network configuration
     - name: Backup current network configuration state to /tmp

--- a/scripts/lint_no_interactive_prompts.py
+++ b/scripts/lint_no_interactive_prompts.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Quality lint: fail if any Ansible playbook contains an interactive
+`pause:` (a `prompt:` without a `seconds:` or `minutes:` timer).
+
+Thinkube playbooks are designed to be orchestrated by the installer or
+thinkube-control. Neither can respond to ansible pause prompts —
+interactive prompts deadlock the orchestrator. When a destructive flow
+needs a safety gate, use the required-extra-var pattern with
+`ansible.builtin.assert` instead.
+
+Exit codes:
+  0 — no interactive prompts found
+  1 — one or more interactive prompts found (paths printed to stderr)
+
+Usage:
+  scripts/lint_no_interactive_prompts.py [path ...]    # default: ansible/
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Matches every `pause:` block, with or without a preceding `- name:` and
+# with or without the `ansible.builtin.` collection prefix. Captures the
+# indentation so we can identify the body of the block.
+PAUSE_RE = re.compile(
+    r"^(?P<indent>\s*)(?:- name: .*\n(?P=indent)\s+)?"
+    r"(?:ansible\.builtin\.)?pause:\s*\n"
+    r"(?P<body>(?:(?P=indent)\s+\S.*\n)*)",
+    re.MULTILINE,
+)
+TIMER_RE = re.compile(r"^\s*(?:seconds|minutes):", re.MULTILINE)
+PROMPT_RE = re.compile(r"^\s*prompt:", re.MULTILINE)
+
+
+def scan_file(path: Path) -> list[int]:
+    """Return line numbers of interactive pauses in `path`."""
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    offenders: list[int] = []
+    for m in PAUSE_RE.finditer(content):
+        body = m.group("body")
+        has_timer = bool(TIMER_RE.search(body))
+        has_prompt = bool(PROMPT_RE.search(body))
+        if has_prompt and not has_timer:
+            line_no = content[: m.start()].count("\n") + 1
+            offenders.append(line_no)
+    return offenders
+
+
+def scan_tree(roots: list[Path]) -> dict[Path, list[int]]:
+    """Walk each root, scan every *.yaml / *.yml file."""
+    results: dict[Path, list[int]] = {}
+    for root in roots:
+        if root.is_file():
+            offs = scan_file(root)
+            if offs:
+                results[root] = offs
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            # Skip hidden / vendored / cache trees
+            dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "node_modules"]
+            for fname in filenames:
+                if not (fname.endswith(".yaml") or fname.endswith(".yml")):
+                    continue
+                p = Path(dirpath) / fname
+                offs = scan_file(p)
+                if offs:
+                    results[p] = offs
+    return results
+
+
+def main(argv: list[str]) -> int:
+    roots = [Path(a) for a in argv[1:]] or [Path("ansible")]
+    for r in roots:
+        if not r.exists():
+            print(f"lint_no_interactive_prompts: path not found: {r}", file=sys.stderr)
+            return 2
+
+    offenders = scan_tree(roots)
+    if not offenders:
+        print("lint_no_interactive_prompts: no interactive pause: prompts found")
+        return 0
+
+    print("lint_no_interactive_prompts: FOUND interactive `pause:` prompts:", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  All Thinkube playbooks must be orchestratable by the installer", file=sys.stderr)
+    print("  or thinkube-control. Interactive prompts deadlock the orchestrator.", file=sys.stderr)
+    print("  Use `ansible.builtin.assert` with a required extra-var instead.", file=sys.stderr)
+    print("", file=sys.stderr)
+    total = 0
+    for path in sorted(offenders):
+        for line_no in offenders[path]:
+            print(f"  {path}:{line_no}", file=sys.stderr)
+            total += 1
+    print("", file=sys.stderr)
+    print(f"  {total} interactive prompt(s) in {len(offenders)} file(s).", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
All Thinkube playbooks are orchestrated by the installer or
thinkube-control. Neither can respond to ansible \`pause:\` prompts —
interactive prompts deadlock the orchestrator indefinitely. When a
destructive flow needs a safety gate, use \`ansible.builtin.assert\`
with a required extra-var.

## What this adds

\`scripts/lint_no_interactive_prompts.py\` — walks \`ansible/\` (or
paths passed on argv), finds every \`pause:\` block with a \`prompt:\`
but no \`seconds:\` / \`minutes:\` timer, reports each offender with
file:line, and exits 1. Pure stdlib; suitable for a CI gate.

## What this fixes

Three pre-existing interactive prompts (unrelated to the kubeadm
migration — these exist on main today):

- \`ansible/00_initial_setup/19_reset_ssh_config.yaml:43\`
- \`ansible/00_initial_setup/29_reset_environment.yaml:40\`
- \`ansible/10_baremetal_infra/19_restore_direct_network.yaml:43\`

Each replaced with \`assert\` on a required extra-var:
- \`ssh_reset_confirmed=true\`
- \`env_reset_confirmed=true\`
- \`network_restore_confirmed=true\`

\`fail_msg\` includes what gets destroyed and how to set the var.

## Note on merge order

The lint script will still exit 1 on \`main\` until
\`feature/kubeadm-migration\` (which includes \`feature/kubeadm-rollback\`)
lands — two interactive prompts remain in the k8s-snap-era
\`29_rollback_workers.yaml\` on main, rewritten in that branch. This PR
itself is independent of the kubeadm series and can land first; just be
aware that any future CI gate on the lint must wait for the migration
branch to merge before turning red builds into failures.

## Standalone — not part of the kubeadm series

This branch is off \`main\`, not off \`feature/kubeadm-migration\`. It
addresses the quality rule directly: any playbook in the tree must be
orchestratable. Mergeable independently.