### PR TITLE
dns-server: standard ctr socket path under kubeadm

### DIFF
--- a/ansible/40_thinkube/core/infrastructure/dns-server/10_deploy.yaml
+++ b/ansible/40_thinkube/core/infrastructure/dns-server/10_deploy.yaml
@@ -194,7 +194,7 @@
 
     - name: Import image into containerd
       ansible.builtin.shell: |
-        sudo /snap/k8s/current/bin/ctr --address /var/lib/k8s-containerd/k8s-containerd/run/containerd/containerd.sock --namespace k8s.io images import {{ bind9_build_dir }}/thinkube-bind9.tar
+        sudo ctr --address /run/containerd/containerd.sock --namespace k8s.io images import {{ bind9_build_dir }}/thinkube-bind9.tar
       changed_when: true
 
     - name: Clean up build artifacts


### PR DESCRIPTION
Phase 3 of the kubeadm migration. One-line fix.

- `/snap/k8s/current/bin/ctr --address /var/lib/k8s-containerd/k8s-containerd/run/containerd/containerd.sock` → `ctr --address /run/containerd/containerd.sock`

ctr from containerd.io is installed at /usr/bin/ctr (on PATH); the snap-isolated socket becomes the standard one.

Refs: KUBEADM_MIGRATION_PLAN.md §6.6