### PR TITLE
inventory: seaweedfs_*_hostname → object_storage_*_hostname (first slice)

### DIFF
--- a/ansible/40_thinkube/core/argo-workflows/13_setup_artifacts.yaml
+++ b/ansible/40_thinkube/core/argo-workflows/13_setup_artifacts.yaml
@@ -50,7 +50,7 @@
     # SeaweedFS S3 connection details
     ###################################################################
     s3_endpoint_internal: "seaweedfs-filer.{{ seaweedfs_namespace }}.svc.cluster.local:8333"
-    s3_endpoint_external: "https://{{ seaweedfs_s3_hostname }}"
+    s3_endpoint_external: "https://{{ object_storage_s3_hostname }}"
     s3_bucket: "argo-artifacts"
     
     ###################################################################
@@ -155,8 +155,8 @@
           [default]
           access_key = {{ s3_access_key }}
           secret_key = {{ s3_secret_key }}
-          host_base = {{ seaweedfs_s3_hostname }}
-          host_bucket = {{ seaweedfs_s3_hostname }}/%(bucket)s
+          host_base = {{ object_storage_s3_hostname }}
+          host_bucket = {{ object_storage_s3_hostname }}/%(bucket)s
           use_https = True
           check_ssl_certificate = False
           signature_v2 = True

--- a/ansible/40_thinkube/core/argo-workflows/README.md
+++ b/ansible/40_thinkube/core/argo-workflows/README.md
@@ -142,7 +142,7 @@ The following variables are used:
 | `admin_username` | Admin username | `tkadmin` |
 | `auth_realm_username` | Realm username for SSO | `thinkube` |
 | `argo_namespace` | Kubernetes namespace | `argo` |
-| `seaweedfs_s3_hostname` | S3 API hostname | `s3.thinkube.com` |
+| `object_storage_s3_hostname` | S3 API hostname | `s3.thinkube.com` |
 | `kubeconfig` | Kubernetes config path | `/etc/kubernetes/admin.conf` |
 | `kubectl_bin` | Path to kubectl binary | `kubectl` |
 | `helm_bin` | Path to helm binary | `helm` |

--- a/ansible/40_thinkube/core/mlflow/11_deploy.yaml
+++ b/ansible/40_thinkube/core/mlflow/11_deploy.yaml
@@ -31,7 +31,7 @@
 # Variables from inventory:
 #   - mlflow_hostname: Hostname for MLflow UI access
 #   - postgres_hostname: PostgreSQL server hostname
-#   - seaweedfs_s3_hostname: SeaweedFS S3 API hostname
+#   - object_storage_s3_hostname: SeaweedFS S3 API hostname
 #   - keycloak_url: URL to Keycloak instance
 #   - keycloak_realm: Keycloak realm name
 #   - harbor_registry: Harbor registry domain
@@ -229,8 +229,8 @@
         s3cmd --config=/dev/null \
           --access_key="{{ s3_access_key }}" \
           --secret_key="{{ s3_secret_key }}" \
-          --host="https://{{ seaweedfs_s3_hostname }}" \
-          --host-bucket="https://{{ seaweedfs_s3_hostname }}/%(bucket)s" \
+          --host="https://{{ object_storage_s3_hostname }}" \
+          --host-bucket="https://{{ object_storage_s3_hostname }}/%(bucket)s" \
           --no-ssl-certificate-check \
           --signature-v2 \
           mb s3://{{ mlflow_artifacts_bucket }} 2>&1 || true

--- a/ansible/40_thinkube/core/mlflow/19_rollback.yaml
+++ b/ansible/40_thinkube/core/mlflow/19_rollback.yaml
@@ -185,8 +185,8 @@
         s3cmd --config=/dev/null \
           --access_key="{{ seaweedfs_secret.resources[0].data.access_key | b64decode }}" \
           --secret_key="{{ seaweedfs_secret.resources[0].data.secret_key | b64decode }}" \
-          --host="https://{{ seaweedfs_s3_hostname }}" \
-          --host-bucket="https://{{ seaweedfs_s3_hostname }}/%(bucket)s" \
+          --host="https://{{ object_storage_s3_hostname }}" \
+          --host-bucket="https://{{ object_storage_s3_hostname }}/%(bucket)s" \
           --no-ssl-certificate-check \
           --signature-v2 \
           rb s3://{{ mlflow_artifacts_bucket }} --force 2>&1 || true

--- a/ansible/40_thinkube/core/mlflow/README.md
+++ b/ansible/40_thinkube/core/mlflow/README.md
@@ -131,7 +131,7 @@ Required inventory variables:
 - `auth_realm_username`: SSO user for role assignments (typically 'thinkube')
 - `kubeconfig`: Path to kubeconfig file
 - `postgres_hostname`: PostgreSQL server hostname
-- `seaweedfs_s3_hostname`: SeaweedFS S3 API hostname
+- `object_storage_s3_hostname`: SeaweedFS S3 API hostname
 - `keycloak_url`: Keycloak server URL
 - `keycloak_realm`: Keycloak realm name
 - `harbor_registry`: Harbor registry domain
@@ -234,7 +234,7 @@ kubectl get secret mlflow-s3-secret -n mlflow -o yaml
 s3cmd --config=/dev/null \
   --access_key="<access-key>" \
   --secret_key="<secret-key>" \
-  --host="https://{{ seaweedfs_s3_hostname }}" \
+  --host="https://{{ object_storage_s3_hostname }}" \
   --no-ssl-certificate-check \
   --signature-v2 \
   ls s3://mlflow/

--- a/ansible/40_thinkube/core/seaweedfs/10_deploy.yaml
+++ b/ansible/40_thinkube/core/seaweedfs/10_deploy.yaml
@@ -229,7 +229,7 @@
             s3:
               enabled: true
               port: 8333
-              domainName: "{{ seaweedfs_s3_hostname }}"
+              domainName: "{{ object_storage_s3_hostname }}"
             persistence:
               enabled: true
               size: 10Gi
@@ -398,10 +398,10 @@
       vars:
         oauth2_proxy_namespace: "{{ seaweedfs_namespace }}"
         oauth2_proxy_client_id: "oauth2-proxy-{{ app_name }}"
-        oauth2_proxy_dashboard_host: "{{ seaweedfs_ui_hostname }}"
+        oauth2_proxy_dashboard_host: "{{ object_storage_ui_hostname }}"
         oauth2_proxy_oidc_issuer_url: "{{ keycloak_url }}/realms/{{ keycloak_realm }}"
         oauth2_proxy_cookie_domain: "{{ domain_name }}"
-        oauth2_proxy_ingress_host: "{{ seaweedfs_ui_hostname }}"
+        oauth2_proxy_ingress_host: "{{ object_storage_ui_hostname }}"
         oauth2_proxy_ingress_tls_secret_name: "{{ tls_secret_name }}"
         oauth2_proxy_kubeconfig: "{{ kubeconfig }}"
         oauth2_proxy_helm_bin: "{{ helm_bin }}"
@@ -429,7 +429,7 @@
               namespace: "{{ gateway_namespace }}"
               sectionName: https
           hostnames:
-            - "{{ seaweedfs_ui_hostname }}"
+            - "{{ object_storage_ui_hostname }}"
           rules:
             - matches:
                 - path:
@@ -459,7 +459,7 @@
               namespace: "{{ gateway_namespace }}"
               sectionName: https
           hostnames:
-            - "{{ seaweedfs_s3_hostname }}"
+            - "{{ object_storage_s3_hostname }}"
           rules:
             - matches:
                 - path:
@@ -496,7 +496,7 @@
         msg:
           - "SeaweedFS deployment complete"
           - "-----------------------------------"
-          - "Web UI (Keycloak protected): https://{{ seaweedfs_ui_hostname }}"
-          - "S3 API endpoint: https://{{ seaweedfs_s3_hostname }}"
+          - "Web UI (Keycloak protected): https://{{ object_storage_ui_hostname }}"
+          - "S3 API endpoint: https://{{ object_storage_s3_hostname }}"
           - "-----------------------------------"
           - "To configure S3 access, use 15_configure.yaml"

--- a/ansible/40_thinkube/core/seaweedfs/15_configure.yaml
+++ b/ansible/40_thinkube/core/seaweedfs/15_configure.yaml
@@ -39,7 +39,7 @@
         description: "General data storage"
     
     # S3 endpoint
-    s3_endpoint: "https://{{ seaweedfs_s3_hostname }}"
+    s3_endpoint: "https://{{ object_storage_s3_hostname }}"
     s3_endpoint_internal: "http://seaweedfs-filer.{{ seaweedfs_namespace }}.svc.cluster.local:8333"
 
   tasks:
@@ -171,5 +171,5 @@
           - "  - Argo secret: argo/argo-artifacts-s3"
           - "-----------------------------------"
           - "To use with s3cmd:"
-          - "  s3cmd --access_key={{ s3_access_key }} --secret_key=<secret> --host={{ seaweedfs_s3_hostname }} --host-bucket=%(bucket)s.{{ seaweedfs_s3_hostname }} ls"
+          - "  s3cmd --access_key={{ s3_access_key }} --secret_key=<secret> --host={{ object_storage_s3_hostname }} --host-bucket=%(bucket)s.{{ object_storage_s3_hostname }} ls"
 

--- a/ansible/40_thinkube/core/seaweedfs/18_test.yaml
+++ b/ansible/40_thinkube/core/seaweedfs/18_test.yaml
@@ -177,7 +177,7 @@
     # Test S3 API endpoint
     - name: Test S3 API endpoint connectivity
       ansible.builtin.uri:
-        url: "https://{{ seaweedfs_s3_hostname }}"
+        url: "https://{{ object_storage_s3_hostname }}"
         validate_certs: false
         status_code: [200, 403]
       register: s3_test
@@ -191,7 +191,7 @@
     # Test UI endpoint (through OAuth2)
     - name: Test UI endpoint connectivity
       ansible.builtin.uri:
-        url: "https://{{ seaweedfs_ui_hostname }}"
+        url: "https://{{ object_storage_ui_hostname }}"
         validate_certs: false
         status_code: [200, 302]
         follow_redirects: no

--- a/ansible/40_thinkube/core/seaweedfs/templates/s3cmd.cfg.j2
+++ b/ansible/40_thinkube/core/seaweedfs/templates/s3cmd.cfg.j2
@@ -4,8 +4,8 @@
 [default]
 access_key = {{ s3_access_key }}
 secret_key = {{ s3_secret_key }}
-host_base = {{ seaweedfs_s3_hostname }}
-host_bucket = {{ seaweedfs_s3_hostname }}/%(bucket)s
+host_base = {{ object_storage_s3_hostname }}
+host_bucket = {{ object_storage_s3_hostname }}/%(bucket)s
 use_https = True
 check_ssl_certificate = False
 signature_v2 = True

--- a/ansible/40_thinkube/optional/langfuse/11_deploy.yaml
+++ b/ansible/40_thinkube/optional/langfuse/11_deploy.yaml
@@ -138,7 +138,7 @@
       ansible.builtin.set_fact:
         s3_access_key: "{{ seaweedfs_secret.resources[0].data.access_key | b64decode }}"
         s3_secret_key: "{{ seaweedfs_secret.resources[0].data.secret_key | b64decode }}"
-        seaweedfs_s3_hostname: "s3.{{ domain_name }}"
+        object_storage_s3_hostname: "s3.{{ domain_name }}"
         langfuse_s3_events_bucket: "langfuse-events"
         langfuse_s3_media_bucket: "langfuse-media"
 
@@ -147,8 +147,8 @@
         s3cmd --config=/dev/null \
           --access_key="{{ s3_access_key }}" \
           --secret_key="{{ s3_secret_key }}" \
-          --host="https://{{ seaweedfs_s3_hostname }}" \
-          --host-bucket="https://{{ seaweedfs_s3_hostname }}/%(bucket)s" \
+          --host="https://{{ object_storage_s3_hostname }}" \
+          --host-bucket="https://{{ object_storage_s3_hostname }}/%(bucket)s" \
           --no-ssl-certificate-check \
           --signature-v2 \
           mb s3://{{ langfuse_s3_events_bucket }} 2>&1 || true
@@ -160,8 +160,8 @@
         s3cmd --config=/dev/null \
           --access_key="{{ s3_access_key }}" \
           --secret_key="{{ s3_secret_key }}" \
-          --host="https://{{ seaweedfs_s3_hostname }}" \
-          --host-bucket="https://{{ seaweedfs_s3_hostname }}/%(bucket)s" \
+          --host="https://{{ object_storage_s3_hostname }}" \
+          --host-bucket="https://{{ object_storage_s3_hostname }}/%(bucket)s" \
           --no-ssl-certificate-check \
           --signature-v2 \
           mb s3://{{ langfuse_s3_media_bucket }} 2>&1 || true

--- a/inventory/group_vars/k8s.yml
+++ b/inventory/group_vars/k8s.yml
@@ -35,10 +35,14 @@ argo_subdomain: "argo"
 prometheus_subdomain: "prometheus"
 jupyter_subdomain: "jupyter"
 
-# SeaweedFS configuration
+# Object storage (capability) — SeaweedFS today (self-hosted connector).
+# Implementation-named vars (e.g. seaweedfs_namespace = the k8s namespace
+# where the chart installs) stay implementation-named on purpose; only
+# user-facing surface (hostnames consumed by apps) uses the capability-
+# neutral object_storage_* prefix. See KUBEADM_MIGRATION_PLAN.md §5.5.
 seaweedfs_namespace: "seaweedfs"
-seaweedfs_s3_hostname: "s3.{{ domain_name }}"
-seaweedfs_ui_hostname: "seaweedfs.{{ domain_name }}"
+object_storage_s3_hostname: "s3.{{ domain_name }}"
+object_storage_ui_hostname: "seaweedfs.{{ domain_name }}"
 
 # JuiceFS configuration
 juicefs_namespace: "juicefs"


### PR DESCRIPTION
Phase 3 of the kubeadm migration. First slice of the capability-neutral naming discipline from §5.5.

User-facing hostname vars get the capability-prefix; implementation-specific surface (k8s namespace names, tuning, chart-internal config) keeps the implementation name.

- `seaweedfs_s3_hostname` → `object_storage_s3_hostname` (17 refs across mlflow / langfuse / seaweedfs / argo)
- `seaweedfs_ui_hostname` → `object_storage_ui_hostname` (5 refs in seaweedfs deploy/test)

**Untouched (intentional):**
- `seaweedfs_namespace` — the k8s namespace name IS seaweedfs by deliberate choice; operators run `kubectl get pods -n seaweedfs` and need to know what's running.
- All other implementation-named vars (harbor_*, keycloak_*, gitea_*, argocd_*, etc.) — broader sweep continues in follow-on PRs to keep each change focused.

Added a comment in `inventory/group_vars/k8s.yml` documenting the rule so future additions follow it.

Refs: KUBEADM_MIGRATION_PLAN.md §5.5