### PR TITLE
perses: promote thinkube_monitor_repo to inventory/group_vars/all.yml

### DIFF
--- a/ansible/40_thinkube/optional/perses/14_import_dashboards_percli.yaml
+++ b/ansible/40_thinkube/optional/perses/14_import_dashboards_percli.yaml
@@ -47,7 +47,9 @@
     prometheus_url: "http://prometheus-k8s.{{ prometheus_namespace }}.svc.cluster.local:9090"
     work_dir: "/tmp/perses-dashboards"
     thinkube_monitor_version: "main"  # Use main branch for latest
-    thinkube_monitor_repo: "https://github.com/thinkube/thinkube-monitor.git"
+    # thinkube_monitor_repo is defined in inventory/group_vars/all.yml so
+    # contributors can override via inventory or -e extra-vars without
+    # editing this playbook. See thinkube-installer/CONTRIBUTING.md.
 
     # Dashboard categories from thinkube-monitor repository
     # Each maps to a Perses project

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,0 +1,14 @@
+# Copyright 2025 Alejandro Martínez Corriá and the Thinkube contributors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Variables that apply to ALL hosts in the inventory.
+#
+# Contributors testing a fork can override any of these via the
+# generated inventory or via `-e var=value` extra-vars without editing
+# the upstream defaults. See thinkube-installer/CONTRIBUTING.md.
+
+# URL of the thinkube-monitor repo cloned by the perses playbook to
+# import Perses dashboards. Contributors point this at their fork when
+# iterating on dashboards.
+thinkube_monitor_repo: "https://github.com/thinkube/thinkube-monitor.git"


### PR DESCRIPTION
Phase 4 of the kubeadm migration. Lets contributors point at a forked thinkube-monitor repo without editing the perses playbook:

    -e thinkube_monitor_repo=https://github.com/<fork>/thinkube-monitor.git

(or override in the generated inventory).

- New file: `inventory/group_vars/all.yml` with the var as a default.
- `perses/14_import_dashboards_percli.yaml`: removed the inline declaration from the play's `vars:` block. Ansible's variable precedence means the playbook still reads the same value — just from `group_vars` instead of inline. Override is now possible without playbook surgery.

The new `all.yml` file is also where future cross-host defaults land when needed.

Refs: thinkube-installer/KUBEADM_MIGRATION_PLAN.md §6.10