### PR TITLE
feat(code-server): provision the Tandem sidecar board repo (SP-10)

### DIFF
--- a/ansible/40_thinkube/core/code-server/15_configure_environment.yaml
+++ b/ansible/40_thinkube/core/code-server/15_configure_environment.yaml
@@ -20,11 +20,15 @@
 - name: Configure code-server environment
   hosts: k8s_control_plane
   gather_facts: true
-  
+
   vars:
     code_server_namespace: "code-server"
     shared_code_path: "/home/{{ system_username }}/shared-code"
     code_source_path: "{{ shared_code_path }}"
+    # The central Tandem board repo (ADR-0008 / SP-10): one repo holding every
+    # Thinking Space's board, cloned beside the workspace roots.
+    board_repo_name: "thinkube-tandem"
+    board_repo_path: "/home/{{ system_username }}/{{ board_repo_name }}"
 
   tasks:
     - name: Get code-server pod name
@@ -36,7 +40,8 @@
         KUBECONFIG: "{{ kubeconfig }}"
       register: pod_name
       failed_when: pod_name.stdout == ""
-      
+      tags: board-repo
+
     - name: Wait for pod to be ready
       kubernetes.core.k8s_info:
         kubeconfig: "{{ kubeconfig }}"
@@ -79,7 +84,7 @@
           GITHUB_TOKEN={{ lookup('env', 'GITHUB_TOKEN') }}
           GITHUB_ORG={{ lookup('env', 'GITHUB_ORG') }}
           THINKUBE_BRANCH={{ lookup('env', 'THINKUBE_BRANCH') | default('main', true) }}
-        mode: '0600'
+        mode: "0600"
       no_log: true
 
     ###################################################################
@@ -388,12 +393,12 @@
 
           [ssh_connection]
           ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
-          
+
     - name: Create temporary Ansible configuration file
       ansible.builtin.copy:
         content: "{{ ansible_cfg_content }}"
         dest: /tmp/ansible-cfg-{{ ansible_date_time.epoch }}
-        mode: '0644'
+        mode: "0644"
       register: temp_ansible_cfg
 
     - name: Copy Ansible configuration to pod
@@ -418,22 +423,22 @@
       ansible.builtin.file:
         path: "{{ shared_code_path }}/.ansible/inventory"
         state: directory
-        mode: '0755'
+        mode: "0755"
       when: inventory_check.stdout == "missing"
 
     - name: Copy entire inventory directory to shared location if missing
       ansible.builtin.copy:
         src: "{{ inventory_dir }}/"
         dest: "{{ shared_code_path }}/.ansible/inventory/"
-        mode: '0644'
-        directory_mode: '0755'
+        mode: "0644"
+        directory_mode: "0755"
       when: inventory_check.stdout == "missing"
 
     # Update Python interpreters in inventory using a Python script
     - name: Create Python script to update inventory
       ansible.builtin.copy:
         dest: /tmp/update_inventory_interpreters.py
-        mode: '0755'
+        mode: "0755"
         content: |
           #!/usr/bin/env python3
           import yaml
@@ -512,7 +517,7 @@
       ansible.builtin.template:
         src: templates/clone_platform_repos.sh.j2
         dest: "/tmp/clone_platform_repos.sh"
-        mode: '0755'
+        mode: "0755"
       vars:
         clone_branch: "{{ lookup('env', 'THINKUBE_BRANCH') | default('main', true) }}"
 
@@ -555,7 +560,7 @@
       ansible.builtin.template:
         src: templates/clone_user_repos.sh.j2
         dest: "/tmp/clone_user_repos.sh"
-        mode: '0755'
+        mode: "0755"
       when: user_templates_to_clone is defined and user_templates_to_clone | length > 0
 
     - name: Copy user clone script into code-server pod
@@ -732,6 +737,39 @@
           "
       no_log: true
       when: github_token is defined and github_token | length > 0
+      tags: board-repo
+
+    # ── Tandem board repo (ADR-0008 / SP-10) ─────────────────────────────────
+    - name: Render Tandem board-repo provisioning script
+      ansible.builtin.template:
+        src: templates/clone_board_repo.sh.j2
+        dest: /tmp/clone_board_repo.sh
+        mode: "0755"
+      tags: board-repo
+
+    - name: Copy board-repo script into code-server pod
+      ansible.builtin.shell: |
+        {{ kubectl_bin }} cp /tmp/clone_board_repo.sh \
+          {{ code_server_namespace }}/{{ pod_name.stdout }}:/tmp/clone_board_repo.sh
+      tags: board-repo
+
+    - name: Provision the Tandem board repo (create-if-absent + clone)
+      ansible.builtin.shell: |
+        {{ kubectl_bin }} exec -n {{ code_server_namespace }} {{ pod_name.stdout }} -- \
+          bash /tmp/clone_board_repo.sh
+      register: board_repo_result
+      tags: board-repo
+
+    - name: Clean up board-repo script
+      ansible.builtin.file:
+        path: /tmp/clone_board_repo.sh
+        state: absent
+      tags: board-repo
+
+    - name: Display board-repo provisioning output
+      ansible.builtin.debug:
+        var: board_repo_result.stdout_lines
+      tags: board-repo
 
     - name: Get ArgoCD token from .env
       ansible.builtin.shell: grep ARGOCD_DEPLOYMENT_SECRET {{ ansible_env.HOME }}/.env | cut -d= -f2 | tr -d '"'
@@ -743,7 +781,7 @@
       ansible.builtin.template:
         src: templates/argocd_config.j2
         dest: /tmp/argocd-config
-        mode: '0600'
+        mode: "0600"
       vars:
         argocd_deployment_token: "{{ argocd_token_result.stdout }}"
       no_log: true
@@ -761,7 +799,7 @@
       ansible.builtin.template:
         src: templates/argo_config.j2
         dest: /tmp/argo-config
-        mode: '0600'
+        mode: "0600"
       vars:
         argo_grpc_domain: "grpc-argo.{{ domain_name }}"
       no_log: true
@@ -814,7 +852,7 @@
       ansible.builtin.template:
         src: templates/docker-config.json.j2
         dest: /tmp/docker-config.json
-        mode: '0600'
+        mode: "0600"
       vars:
         harbor_auth_b64: "{{ harbor_auth_result.stdout }}"
       no_log: true
@@ -845,7 +883,7 @@
       ansible.builtin.template:
         src: templates/test-cli-tools.sh.j2
         dest: /tmp/test-cli-tools-{{ ansible_date_time.epoch }}.sh
-        mode: '0755'
+        mode: "0755"
       register: test_script
 
     - name: Copy test script to code-server pod
@@ -865,7 +903,7 @@
       ansible.builtin.template:
         src: templates/test-cli-tools.fish.j2
         dest: /tmp/test-cli-tools-{{ ansible_date_time.epoch }}.fish
-        mode: '0755'
+        mode: "0755"
       register: test_script_fish
 
     - name: Copy Fish test script to code-server pod
@@ -925,12 +963,12 @@
               "**/.bash_history": true
             }
           }
-          
+
     - name: Create .vscode directory
       ansible.builtin.shell: |
         {{ kubectl_bin }} exec -n {{ code_server_namespace }} {{ pod_name.stdout }} -- \
           bash -c "mkdir -p /home/thinkube/.vscode"
-          
+
     - name: Copy VS Code workspace settings
       ansible.builtin.shell: |
         {{ kubectl_bin }} exec -n {{ code_server_namespace }} {{ pod_name.stdout }} -- \
@@ -942,13 +980,13 @@
       ansible.builtin.file:
         path: "{{ code_source_path }}/apps"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Create Thinkube workspace file
       ansible.builtin.template:
         src: thinkube.code-workspace.j2
         dest: "{{ code_source_path }}/thinkube.code-workspace"
-        mode: '0644'
+        mode: "0644"
 
     - name: Ensure VS Code extensions directory exists
       ansible.builtin.shell: |
@@ -1028,19 +1066,19 @@
     - name: Display thinkube-theme installation output
       ansible.builtin.debug:
         var: theme_install.stdout_lines
-      
+
     - name: Create temporary settings file from template
       ansible.builtin.template:
         src: templates/vscode-settings.json.j2
         dest: /tmp/vscode-settings-{{ ansible_date_time.epoch }}.json
-        mode: '0644'
+        mode: "0644"
       register: temp_settings_file
 
     - name: Ensure VS Code user settings directory exists on host with correct permissions
       ansible.builtin.file:
         path: "{{ code_source_path }}/.local/share/code-server/User"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Check if existing settings file exists on host
       ansible.builtin.stat:
@@ -1075,7 +1113,7 @@
       ansible.builtin.copy:
         content: "{{ merged_vscode_settings | to_nice_json(indent=4) }}"
         dest: /tmp/vscode-settings-merged-{{ ansible_date_time.epoch }}.json
-        mode: '0644'
+        mode: "0644"
       register: merged_settings_file
 
     - name: Get current code-server pod name
@@ -1106,7 +1144,7 @@
       ansible.builtin.file:
         path: "{{ merged_settings_file.dest }}"
         state: absent
-      
+
     - name: Display extension configuration output
       ansible.builtin.debug:
         var: extension_config.stdout_lines

--- a/ansible/40_thinkube/core/code-server/18_test.yaml
+++ b/ansible/40_thinkube/core/code-server/18_test.yaml
@@ -24,6 +24,12 @@
     code_server_namespace: "code-server"
     code_server_hostname: "code.{{ domain_name }}"
     test_timeout: 300
+    # Tandem board repo provisioning (ADR-0008 / SP-10). In-pod paths: the
+    # shared-code mount surfaces the host staging dir at /home/{{ system_username }}.
+    board_repo_name: "thinkube-tandem"
+    board_repo_path: "/home/{{ system_username }}/{{ board_repo_name }}"
+    board_workspace_file: "/home/{{ system_username }}/thinkube.code-workspace"
+    board_user_settings: "/home/{{ system_username }}/.local/share/code-server/User/settings.json"
 
   tasks:
     ###################################################################
@@ -46,7 +52,7 @@
         namespace: "{{ code_server_namespace }}"
         name: code-server
       register: deployment_check
-      failed_when: 
+      failed_when:
         - deployment_check.resources | length == 0
         - deployment_check.resources[0].status.readyReplicas != 1
 
@@ -59,7 +65,7 @@
         label_selectors:
           - "app.kubernetes.io/name=oauth2-proxy"
       register: oauth_deployment
-      failed_when: 
+      failed_when:
         - oauth_deployment.resources | length == 0
         - oauth_deployment.resources[0].status.readyReplicas is not defined
 
@@ -71,7 +77,7 @@
         namespace: "{{ code_server_namespace }}"
         name: ephemeral-valkey
       register: valkey_deployment
-      failed_when: 
+      failed_when:
         - valkey_deployment.resources | length == 0
         - valkey_deployment.resources[0].status.readyReplicas != 1
 
@@ -232,19 +238,63 @@
       failed_when: false
 
     ###################################################################
+    # 8.5) Check Tandem board repo provisioning (ADR-0008 / SP-10)
+    ###################################################################
+    - name: Check the Tandem board repo is cloned
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ kubeconfig }}"
+        namespace: "{{ code_server_namespace }}"
+        pod: "{{ code_server_pod_info.resources[0].metadata.name }}"
+        command: test -d {{ board_repo_path }}/.git
+      register: board_repo_check
+      when: code_server_pod_info.resources | length > 0
+      changed_when: false
+      failed_when: board_repo_check.rc is not defined or board_repo_check.rc != 0
+
+    - name: Check the "Tandem" workspace root is configured
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ kubeconfig }}"
+        namespace: "{{ code_server_namespace }}"
+        pod: "{{ code_server_pod_info.resources[0].metadata.name }}"
+        command: grep -q Tandem {{ board_workspace_file }}
+      register: board_workspace_check
+      when: code_server_pod_info.resources | length > 0
+      changed_when: false
+      failed_when: board_workspace_check.rc is not defined or board_workspace_check.rc != 0
+
+    - name: Check thinkube.boards.root is set in User settings
+      kubernetes.core.k8s_exec:
+        kubeconfig: "{{ kubeconfig }}"
+        namespace: "{{ code_server_namespace }}"
+        pod: "{{ code_server_pod_info.resources[0].metadata.name }}"
+        command: grep -q thinkube.boards.root {{ board_user_settings }}
+      register: board_settings_check
+      when: code_server_pod_info.resources | length > 0
+      changed_when: false
+      failed_when: board_settings_check.rc is not defined or board_settings_check.rc != 0
+
+    - name: Report Tandem board provisioning
+      ansible.builtin.debug:
+        msg: |
+          ✓ Board repo cloned: {{ board_repo_path }}
+          ✓ Workspace root "Tandem" present in {{ board_workspace_file }}
+          ✓ thinkube.boards.root set in {{ board_user_settings }}
+      when: code_server_pod_info.resources | length > 0
+
+    ###################################################################
     # 9) Summary report
     ###################################################################
     - name: Test summary
       ansible.builtin.debug:
         msg: |
-          
+
           ════════════════════════════════════════════════════════
           ✅ Code Server Test Results
           ════════════════════════════════════════════════════════
-          
+
           Namespace: {{ code_server_namespace }}
           URL: https://{{ code_server_hostname }}
-          
+
           Component Status:
           ✓ Code Server deployment: Running
           ✓ OAuth2 Proxy: Running
@@ -254,7 +304,7 @@
           ✓ Keycloak client: Configured
           ✓ Authentication redirect: Working
           {{ '✓ Repository monitor: Running' if monitor_status.status is defined and monitor_status.status.ActiveState == 'active' else '○ Repository monitor: Not configured' }}
-          
+
           Installed Extensions:
           {% if installed_extensions is defined and installed_extensions.stdout_lines is defined %}
           {% for ext in installed_extensions.stdout_lines %}
@@ -265,15 +315,15 @@
           {% else %}
           - Unable to check extensions
           {% endif %}
-          
+
           Access Instructions:
           1. Navigate to https://{{ code_server_hostname }}
           2. Login with Keycloak credentials
           3. VS Code interface should load
-          
+
           Troubleshooting Commands:
           - kubectl -n {{ code_server_namespace }} get pods
           - kubectl -n {{ code_server_namespace }} logs deployment/code-server
           - kubectl -n {{ code_server_namespace }} logs deployment/oauth2-proxy
-          
+
           ════════════════════════════════════════════════════════

--- a/ansible/40_thinkube/core/code-server/templates/clone_board_repo.sh.j2
+++ b/ansible/40_thinkube/core/code-server/templates/clone_board_repo.sh.j2
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Rendered by Ansible — provisions the central Tandem board repo (ADR-0008 / SP-10).
+# Creates {{ github_org }}/{{ board_repo_name }} in the org if it's absent (gh is
+# already authenticated in the pod), then clones (or pulls) it to
+# {{ board_repo_path }} over the github_ed25519 SSH key.
+set -e
+
+REPO="{{ github_org }}/{{ board_repo_name }}"
+DEST="{{ board_repo_path }}"
+KEY="/home/thinkube/.ssh/github_ed25519"
+SSH_CMD="ssh -i $KEY -o StrictHostKeyChecking=no"
+
+echo "===== Provisioning the Tandem board repo ($REPO) ====="
+
+# Create the repo if it doesn't exist yet (idempotent — skip if present).
+if gh repo view "$REPO" >/dev/null 2>&1; then
+  echo "$REPO already exists."
+else
+  echo "Creating $REPO (private)..."
+  gh repo create "$REPO" --private
+fi
+
+if [ ! -f "$KEY" ]; then
+  echo "ERROR: No SSH key at $KEY"
+  exit 1
+fi
+chmod 600 "$KEY"
+export GIT_SSH_COMMAND="$SSH_CMD"
+
+if [ ! -d "$DEST/.git" ]; then
+  echo "Cloning $REPO into $DEST..."
+  git clone "git@github.com:$REPO.git" "$DEST"
+else
+  echo "$DEST already cloned, pulling latest..."
+  cd "$DEST"
+  git fetch origin 2>&1 || echo "(fetch skipped — empty/unreachable remote)"
+  default_branch=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
+  if [ -n "$default_branch" ] && [ "$default_branch" != "(unknown)" ]; then
+    git reset --hard "origin/$default_branch"
+  fi
+fi
+
+# Persist the SSH command so the user's later git ops in the board repo work.
+git -C "$DEST" config core.sshCommand "$SSH_CMD"
+
+echo "✅ Tandem board repo provisioned at $DEST"

--- a/ansible/40_thinkube/core/code-server/templates/thinkube.code-workspace.j2
+++ b/ansible/40_thinkube/core/code-server/templates/thinkube.code-workspace.j2
@@ -11,6 +11,10 @@
     {
       "name": "Platform",
       "path": "/home/thinkube/thinkube-platform"
+    },
+    {
+      "name": "Tandem",
+      "path": "{{ board_repo_path }}"
     }
   ],
   "settings": {

--- a/ansible/40_thinkube/core/code-server/templates/vscode-settings.json.j2
+++ b/ansible/40_thinkube/core/code-server/templates/vscode-settings.json.j2
@@ -11,6 +11,7 @@
     "thinkube-cicd.refreshInterval": 5000,
     "thinkube-cicd.showNotifications": true,
     "thinkube-cicd.notificationLevel": "all",
+    "thinkube.boards.root": "{{ board_repo_path }}",
     "terminal.integrated.defaultProfile.linux": "bash",
     "terminal.integrated.profiles.linux": {
         "bash": {


### PR DESCRIPTION
Extends the code-server deploy to create + clone the central Tandem board repo (`thinkube-tandem`, ADR-0008): create-if-absent in the org, clone to `/home/thinkube/thinkube-tandem` as a 4th "Tandem" workspace root, set `thinkube.boards.root`. `18_test` asserts all three. New tasks tagged `board-repo` to run in isolation (avoiding the full deploy's clone-platform-repos hard-reset).

Verified live: board repo created (`cmxela/thinkube-tandem`) + idempotent re-run; full verification via `--tags board-repo` + `18_test` follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)