### PR TITLE
test(code-server): tag SP-10 board checks for isolated runs

### DIFF
--- a/ansible/40_thinkube/core/code-server/18_test.yaml
+++ b/ansible/40_thinkube/core/code-server/18_test.yaml
@@ -226,6 +226,7 @@
         label_selectors:
           - app=code-server
       register: code_server_pod_info
+      tags: board-test
 
     - name: Check installed extensions
       kubernetes.core.k8s_exec:
@@ -250,6 +251,7 @@
       when: code_server_pod_info.resources | length > 0
       changed_when: false
       failed_when: board_repo_check.rc is not defined or board_repo_check.rc != 0
+      tags: board-test
 
     - name: Check the "Tandem" workspace root is configured
       kubernetes.core.k8s_exec:
@@ -261,6 +263,7 @@
       when: code_server_pod_info.resources | length > 0
       changed_when: false
       failed_when: board_workspace_check.rc is not defined or board_workspace_check.rc != 0
+      tags: board-test
 
     - name: Check thinkube.boards.root is set in User settings
       kubernetes.core.k8s_exec:
@@ -272,6 +275,7 @@
       when: code_server_pod_info.resources | length > 0
       changed_when: false
       failed_when: board_settings_check.rc is not defined or board_settings_check.rc != 0
+      tags: board-test
 
     - name: Report Tandem board provisioning
       ansible.builtin.debug:
@@ -280,6 +284,7 @@
           ✓ Workspace root "Tandem" present in {{ board_workspace_file }}
           ✓ thinkube.boards.root set in {{ board_user_settings }}
       when: code_server_pod_info.resources | length > 0
+      tags: board-test
 
     ###################################################################
     # 9) Summary report


### PR DESCRIPTION
Adds `tags: board-test` to the SP-10 board-provisioning assertions in 18_test (+ the pod-info prereq) so they run in isolation, bypassing a pre-existing auth-redirect assert that halts the full test in the mid-migration cluster. `tk_ansible ... 18_test.yaml --tags board-test` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)